### PR TITLE
Onboard reachy-mini-mcp into the AgentCulture mesh (vendor guildmaster skill kit)

### DIFF
--- a/.claude/skills.local.yaml.example
+++ b/.claude/skills.local.yaml.example
@@ -1,0 +1,16 @@
+# Per-machine config for reachy-mini-mcp's skills.
+# Copy this to skills.local.yaml (git-ignored) and adjust for your environment.
+# Skills read skills.local.yaml first, falling back to this example.
+
+# Path to the Culture server's agent manifest (suffix → directory mapping).
+# Used by: agent-config and any skill that resolves a registered agent
+# suffix to its repo dir.
+culture_server_yaml: ~/.culture/server.yaml
+
+# Sibling project paths checked during the cicd alignment-delta step.
+# Workspace-relative paths (../foo) are preferred. Skills skip entries
+# that don't exist on disk, so commenting out missing ones isn't required.
+sibling_projects:
+  - ../guildmaster
+  - ../steward
+  - ../culture-agent-template

--- a/.claude/skills/agent-config/SKILL.md
+++ b/.claude/skills/agent-config/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: agent-config
+description: >
+  Show a Culture agent's full configuration in one read-only view: its
+  system-prompt file (CLAUDE.md / AGENTS.md / GEMINI.md), the parallel
+  culture.yaml, and the agent's local .claude/skills index. Use when an
+  operator says "show agent <name>", "what does <agent> look like", or before
+  teaching/onboarding an agent and you need to see its current kit + config.
+  Backs the `guild show` verb. Vendored from steward (cite-don't-import);
+  inventory only — it reports, it does not judge alignment or drift.
+type: command
+---
+
+# agent-config — surface a Culture agent's config in one view
+
+guildmaster is the mesh's skills supplier and owns the **inventory** surfaces:
+"what kit + config does this agent have?" This skill answers exactly that for a
+single agent, showing the three artifacts that together define it:
+
+1. **System-prompt file** (`CLAUDE.md` / `AGENTS.md` / `GEMINI.md`) — the
+   prompt-side guidance for the agent's backend. The script detects which file
+   is present from a backend-fingerprint registry.
+2. **`culture.yaml`** — the runtime-side config (`agents:` list with `suffix`,
+   `backend`, `model`, `system_prompt`, `channels`, `tags`, `acp_command`,
+   `extras`). Lives parallel to the prompt file at the project root.
+3. **`.claude/skills/*/SKILL.md`** — the per-project skills the agent can
+   invoke, one line each (name + truncated description).
+
+This is the **inventory half** of the steward → guildmaster split
+([issue #12](https://github.com/agentculture/guildmaster/issues/12)): it reports
+the config, it does **not** interpret drift or judge alignment. The relationship
+graph and the "is this agent aligned?" judgment stay with `steward overview` /
+`steward doctor`.
+
+## When to use
+
+- Before `guild teach` / `guild onboard` — see an agent's current kit + config.
+- When an operator asks "show me agent `<name>`" or "what does `<agent>` run".
+- Read it, don't guess — before answering a question about what an agent does.
+
+## How to run
+
+One script, two ways to call it (or just run `guild show`, which wraps it):
+
+```bash
+# Path mode — point at any directory with a prompt file + culture.yaml
+.claude/skills/agent-config/scripts/show.sh ../culture
+
+# Suffix mode — resolve a registered agent suffix via the Culture server's
+# manifest (location set by culture_server_yaml in skills.local.yaml)
+.claude/skills/agent-config/scripts/show.sh daria
+```
+
+Output is three sections: the detected system-prompt file, `culture.yaml` (or
+`(missing)`), and a one-line summary per local skill (name + description,
+truncated to 120 chars).
+
+## What to look at in `culture.yaml`
+
+| Field | Why it matters |
+|-------|----------------|
+| `suffix` | Identifies the agent on the mesh. |
+| `backend` | One of `claude` / `codex` / `copilot` / `acp`. The all-backends rule means a feature in one must land in all four. |
+| `model` | Drift here changes behavior silently. |
+| `system_prompt` | Should not contradict the prompt file. |
+| `channels` | Where the agent listens. |
+| `tags`, `extras`, `acp_command` | Backend-specific. |
+
+## Notes
+
+- **Read-only.** The script never edits agent files. It reports; it does not
+  flag or fix drift — that judgment is steward's lane.
+- **Backend-aware.** Prompt-file detection comes from
+  `data/backend-fingerprints.yaml` (the `prompt:` mapping), falling back to the
+  built-in `(CLAUDE.md AGENTS.md GEMINI.md)` list if the registry is absent.
+- **Per-machine config.** Suffix mode reads `culture_server_yaml` from
+  `.claude/skills.local.yaml` (git-ignored), falling back to
+  `.claude/skills.local.yaml.example`.
+- **Vendored from steward** (`agent-config`). guildmaster owns this copy and may
+  diverge; re-sync from steward's canonical copy when it changes. Divergences:
+  the SKILL.md is reframed for guildmaster's inventory role and adds
+  `type: command` for the culture backend's skill loader.

--- a/.claude/skills/agent-config/data/backend-fingerprints.yaml
+++ b/.claude/skills/agent-config/data/backend-fingerprints.yaml
@@ -1,0 +1,30 @@
+# Canonical backend fingerprint registry. Vendored from steward's agent-config
+# skill (cite-don't-import); guildmaster owns this copy. Read by the agent-config
+# show.sh (bash), which `guild show` shells out to. Upstream steward also reads
+# it from a Python detector; guildmaster has no parallel detector, so only the
+# `backends:` prompt mapping below is load-bearing here. Keep that mapping in
+# sync with upstream when re-syncing.
+#
+# `prompt`        — the backend's system-prompt filename at the repo root.
+# `steering`      — files/dirs distinctive enough to attribute to this backend.
+# `shared_steering` — files/dirs that belong to NO specific backend. A repo
+#                   declared as any backend may have these without triggering a
+#                   mismatch. `.agents` is a generic Culture agent-config
+#                   convention. `.claude/settings.json` and
+#                   `.claude/settings.local.json` are generic Claude Code
+#                   (editor/CLI) workspace config files — they appear in any
+#                   repo that uses Claude Code as the development tool,
+#                   regardless of the agent backend, so they must never be used
+#                   to infer the backend or flag a mismatch. The claude backend
+#                   is identified solely by its `CLAUDE.md` prompt file.
+#                   `.github/copilot-instructions.md` is generic GitHub Copilot
+#                   editor/IDE config — any repo may have it regardless of the
+#                   declared agent backend, so it must not trigger a mismatch.
+backends:
+  claude:  { prompt: CLAUDE.md, steering: [] }
+  codex:   { prompt: AGENTS.md, steering: [".codex"] }
+  acp:     { prompt: AGENTS.md, steering: [".kiro"] }
+  copilot: { prompt: AGENTS.md, steering: [] }
+  gemini:  { prompt: GEMINI.md, steering: [".gemini"] }
+shared_steering: [".agents", ".claude/settings.json", ".claude/settings.local.json", ".github/copilot-instructions.md"]
+prompt_fallback: AGENTS.md

--- a/.claude/skills/agent-config/scripts/show.sh
+++ b/.claude/skills/agent-config/scripts/show.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Show a Culture agent's full configuration in one view:
+# the detected system-prompt file (CLAUDE.md / AGENTS.md / GEMINI.md), the
+# parallel culture.yaml, and the .claude/skills/ index.
+#
+# Usage: show.sh <path-or-agent-suffix>
+#
+# Path mode:   show.sh ../culture
+# Suffix mode: show.sh daria   (resolved via culture_server_yaml in skills.local.yaml)
+#
+# Exit codes:
+#   0   success
+#   1   environment error (missing manifest, missing PyYAML for suffix mode)
+#   2   user error (no target given, unknown suffix, target path doesn't exist)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SKILL_DIR/../../.." && pwd)"
+
+CFG="$REPO_ROOT/.claude/skills.local.yaml"
+[ -f "$CFG" ] || CFG="$REPO_ROOT/.claude/skills.local.yaml.example"
+
+# Read a top-level YAML scalar from CFG. Schema is intentionally tiny:
+#   key: value     (with optional surrounding quotes / trailing comment)
+# No PyYAML dependency.
+read_cfg() {
+    awk -v key="$1" '
+        $0 ~ ("^" key ":[[:space:]]*") {
+            sub("^" key ":[[:space:]]*", "")
+            sub(/[[:space:]]*#.*$/, "")
+            sub(/^[[:space:]]+/, ""); sub(/[[:space:]]+$/, "")
+            sub(/^["\047]/, ""); sub(/["\047]$/, "")
+            print
+            exit
+        }
+    ' "$CFG"
+}
+
+target="${1:-}"
+if [ -z "$target" ]; then
+    echo "Usage: $(basename "$0") <path-or-agent-suffix>" >&2
+    exit 2
+fi
+
+if [ -d "$target" ]; then
+    DIR="$target"
+else
+    SERVER_YAML_RAW="$(read_cfg culture_server_yaml)"
+    SERVER_YAML="${SERVER_YAML_RAW/#\~/$HOME}"
+    if [ ! -f "$SERVER_YAML" ]; then
+        echo "no server manifest at $SERVER_YAML — set culture_server_yaml in $CFG" >&2
+        echo "or pass an explicit path instead of suffix '$target'" >&2
+        exit 1
+    fi
+    # Suffix mode parses Culture's server manifest, whose schema is dictated by
+    # Culture (not by us) and includes nested mappings — too rich for awk.
+    # We use python+PyYAML here, with a friendly install hint if it's missing.
+    if ! python3 -c 'import yaml' 2>/dev/null; then
+        echo "suffix mode needs Python + PyYAML to parse $SERVER_YAML" >&2
+        echo "  install: pip install --user pyyaml   (or: uv pip install pyyaml)" >&2
+        echo "  or pass an explicit path instead of suffix '$target'" >&2
+        exit 1
+    fi
+    # Use a dedicated exit code (2) for "unknown suffix" so the steward CLI
+    # wrapper can distinguish user errors (typo'd suffix) from env errors
+    # (missing manifest / PyYAML).
+    if ! DIR=$(python3 - "$SERVER_YAML" "$target" <<'PY'
+import sys, yaml, pathlib
+manifest_path, suffix = sys.argv[1], sys.argv[2]
+m = yaml.safe_load(pathlib.Path(manifest_path).read_text()) or {}
+agents = m.get('agents', {})
+entry = agents.get(suffix)
+if entry is None:
+    print(f"no agent registered with suffix {suffix!r} in {manifest_path}", file=sys.stderr)
+    sys.exit(2)
+print(entry['directory'] if isinstance(entry, dict) else entry)
+PY
+); then
+        exit 2
+    fi
+fi
+
+DIR="${DIR/#\~/$HOME}"
+
+# Recognized prompt filenames come from the shared registry (single source
+# of truth with the Python detector). Fall back to the built-in list if the
+# registry isn't present (e.g. skill vendored without the data file).
+REGISTRY="$SKILL_DIR/data/backend-fingerprints.yaml"
+prompt_files=()
+if [ -f "$REGISTRY" ]; then
+    while IFS= read -r pf; do
+        [ -n "$pf" ] && prompt_files+=("$pf")
+    done < <(grep -oE 'prompt:[[:space:]]*[^,}[:space:]]+' "$REGISTRY" | awk '{print $NF}' | sort -u)
+fi
+[ ${#prompt_files[@]} -eq 0 ] && prompt_files=(CLAUDE.md AGENTS.md GEMINI.md)
+
+shown=0
+for pf in "${prompt_files[@]}"; do
+    if [ -f "$DIR/$pf" ]; then
+        echo "=== $DIR/$pf ==="
+        cat "$DIR/$pf"
+        echo
+        shown=1
+    fi
+done
+if [ "$shown" -eq 0 ]; then
+    echo "=== $DIR (system prompt) ==="
+    echo "(no recognized prompt file: ${prompt_files[*]})"
+    echo
+fi
+echo "=== $DIR/culture.yaml ==="
+if [ -f "$DIR/culture.yaml" ]; then cat "$DIR/culture.yaml"; else echo "(missing)"; fi
+echo
+echo "=== $DIR/.claude/skills/ ==="
+found=0
+for s in "$DIR"/.claude/skills/*/SKILL.md; do
+    [ -f "$s" ] || continue
+    found=1
+    name=$(awk '/^name:/{print $2; exit}' "$s")
+    desc=$(awk '
+        /^description:/ {
+            sub(/^description:[[:space:]]*/, "")
+            buf = $0
+            flag = 1
+            next
+        }
+        flag && /^[a-z_-]+:/ { flag = 0 }
+        flag { buf = buf " " $0 }
+        END { gsub(/^[[:space:]]+|[[:space:]]+$/, "", buf); print buf }
+    ' "$s")
+    printf "  %-30s %s\n" "$name" "${desc:0:120}"
+done
+if [ "$found" -eq 0 ]; then
+    echo "  (no skills)"
+fi

--- a/.claude/skills/assign-to-workforce/SKILL.md
+++ b/.claude/skills/assign-to-workforce/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: assign-to-workforce
+type: command
+description: >
+  Fan out a converged devague plan's dependency waves to parallel agents in
+  isolated git worktrees, one agent per task per wave, with TDD-gated merges
+  by the main agent. Human gates: the exported spec, the implementation split
+  plan (task map + per-task agent/model proposal + go/no-go), and the final PR.
+  The devague CLI stays deterministic and non-orchestrating (#20) — it only
+  *describes* the graph via `devague plan waves`; the operator (main agent)
+  performs the fan-out. Use when the user says "assign to workforce",
+  "fan out the plan", "parallel subagents", or after /spec-to-plan exports a
+  plan. Authored and maintained in agentculture/devague (origin = devague);
+  steward pulls this skill from here and broadcasts it to the AgentCulture
+  mesh — it is NOT vendored from steward like the other skills here.
+---
+
+# assign-to-workforce — fan out a converged plan's waves to parallel agents
+
+The skill is named **`assign-to-workforce`**; the product/CLI it reads is the
+**`devague plan waves`** command. (The prior leg — turning a spec into a plan —
+is the sibling **`/spec-to-plan`** skill.)
+
+`assign-to-workforce` takes a **converged devague plan** and fans out its
+dependency waves to parallel agents (subagents, teammate agents, or generalist
+agents) — one agent per task per wave — each working in an **isolated git
+worktree**. The main agent merges each completed worktree gated by TDD. The
+human owns exactly three gates: the exported spec, the implementation split
+plan, and the final PR.
+
+The devague CLI is **never orchestrated by devague itself** — `devague plan
+waves` describes the dependency graph (#20); it does not spawn agents, manage
+worktrees, mark tasks done, or pick a backend. The fan-out is the *operator's*
+job — this skill and the main agent perform it.
+
+## How to run
+
+The entry point is `scripts/assign-to-workforce.sh`. Invoke it from the
+repository whose plan you are implementing (plans persist under `.devague/`
+in the current directory):
+
+```bash
+bash .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh split-plan [--plan <slug>]
+bash .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh waves    [--plan <slug>] [--json]
+bash .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh help
+```
+
+It resolves the CLI portably — an installed `devague` on `PATH` (the normal
+case), falling back to `uv run devague` when you are inside the devague
+checkout, else an install hint. The `split-plan` subcommand reads
+`devague plan waves --json` and renders the human-facing implementation split
+plan: task map, proposed per-task agent + model assignment, and the go/no-go
+question. The `waves` subcommand forwards to `devague plan waves` verbatim.
+
+### Usage
+
+| Subcommand | What it does |
+|------------|--------------|
+| `split-plan [--plan S]` | Read `devague plan waves` and print the implementation split plan — task map with per-task agent + model proposal — ready for human go/no-go review. |
+| `waves [--plan S] [--json]` | Forward to `devague plan waves [--json]`. Read-only; lists wave batches. On a converged plan exits 0 listing the waves. |
+| `help` | Print usage. |
+
+## The full flow
+
+The flow has three human gates and one automated TDD merge loop.
+
+### Human gate 1 — the exported spec
+
+The plan is seeded from a converged frame (`devague plan new --frame <slug>`).
+The human reviewed and approved the spec when it was exported by the `/think`
+skill. No re-approval needed here — the spec gate is already closed.
+
+### Human gate 2 — the implementation split plan
+
+Before any task is assigned, the main agent presents the **implementation split
+plan** for human go/no-go. This is the only gate the human owns at the
+implementation stage (per task, the TDD gate is the main agent's).
+
+The split plan contains:
+
+1. **Task map** — every task id, its one-line summary, acceptance criteria, and
+   the wave it belongs to (from `devague plan waves`).
+2. **Per-task agent + model proposal** — for each task: the proposed agent type
+   (subagent / teammate / generalist), the proposed model (e.g. a cheaper/faster
+   model for a well-scoped task), and the scope justification (why this task is
+   safe to delegate).
+3. **Go/no-go question** — explicit human decision: "Approve this split and
+   assign the plan to the workforce, or edit it first?"
+
+The human may edit any row (agent type, model, scope) before approving. The
+plan is model-agnostic — devague does not pick a backend (#20).
+
+Run `split-plan` to print the proposed table:
+
+```bash
+bash .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh split-plan
+```
+
+Do not proceed to fan-out until the human approves the split plan.
+
+### Fan-out — one agent per task per wave in isolated worktrees
+
+Once the human approves, the main agent fans out each wave in order:
+
+1. **Create an isolated git worktree** for each task in the current wave:
+
+   ```bash
+   git worktree add ../worktrees/agent-<task-id> -b agent/<task-id>
+   ```
+
+2. **Spawn a task agent** inside that worktree (using the approved model from
+   the split plan), with:
+   - The task id, summary, and acceptance criteria as its brief.
+   - Instruction to work **test-first** (TDD): write the failing test(s) that
+     match the acceptance criteria before implementing.
+   - Instruction to commit its work to the worktree branch.
+
+3. **Same-wave tasks run in parallel** (within-wave tasks have no
+   inter-task dependency; the dependency graph guarantees this). Same-file
+   overlap surfaces as a merge conflict at reconcile time, not a live race —
+   isolated worktrees prevent clobbering.
+
+4. **Wait for all tasks in the wave to complete** before starting the next wave.
+
+### TDD-gated merge — main agent, no human per task
+
+For each completed task worktree, the main agent:
+
+1. **Runs the task's tests before merge** (on the main branch): baseline must
+   pass (or the relevant tests must be absent — the task adds them).
+2. **Merges the worktree branch** into the main branch:
+
+   ```bash
+   git merge --no-ff agent/<task-id>
+   ```
+
+3. **Runs the task's tests after merge**: they must pass. If they do not, the
+   merge is reverted and the task agent is given the failure output to fix.
+4. **Removes the worktree** once the merge is accepted:
+
+   ```bash
+   git worktree remove ../worktrees/agent-<task-id>
+   ```
+
+The human does **not** review individual task merges. Per-task acceptance is
+the main agent's responsibility — the TDD gate (tests pass before AND after
+merge) plus the task's acceptance criteria. This mirrors the non-authoritative
+working state pattern of the Human Review Loop (#17): per-task merge records
+are uncommitted working state; the authoritative human gate is the final PR.
+
+Advance to the next wave only after all tasks in the current wave are merged
+and their tests pass.
+
+### Human gate 3 — the final PR
+
+Once all waves are merged and the full test suite passes, the main agent opens
+a PR via the `cicd` skill (`devex pr open`). The human reviews and merges. This
+is the last and only remaining human gate.
+
+## Hard rules (do not violate)
+
+These protect the human-gate contract and the TDD guarantee.
+
+- **Present the split plan before any fan-out.** Never spawn a task agent
+  without prior human approval of the implementation split plan (gate 2). The
+  split plan is the human's only implementation-stage decision.
+- **One worktree per task.** Never run two tasks in the same worktree — file
+  contention is managed by isolation, not by trust in the dependency graph.
+  The dependency graph guarantees *logical* independence within a wave, not
+  *file* disjointness. Conflicts surface at merge time.
+- **Tests before AND after merge — no exceptions.** The TDD gate must pass on
+  both sides. A merge that makes tests pass only after (not before) means the
+  baseline was already broken — fix the baseline first.
+- **Human does not gate per-task merges.** The TDD contract replaces the
+  human here. Do not pause for human approval between wave tasks.
+- **devague CLI is not orchestrated.** `devague plan waves` is read-only
+  scheduling metadata (#20). Never run `devague plan` commands inside a task
+  worktree to "mark a task done" or modify plan state from a subagent.
+- **Three gates only.** The human's gates are: (1) the exported spec, (2) the
+  implementation split plan, (3) the final PR. No silent fourth gate.
+- **No LLM calls in the devague CLI.** The CLI is deterministic. This skill
+  adds orchestration convention, not CLI behavior.
+
+## Output contract
+
+The `split-plan` subcommand prints to **stdout** and exits 0 when a converged
+plan is found. On error (no plan, cyclic graph) it exits non-zero with a
+`hint:` line on stderr. The `waves` subcommand forwards the CLI's own output
+contract (stdout, `--json` for structured output, exit 0 on success).
+
+## Worked example
+
+Picking up after `/spec-to-plan` exported a plan for the frame `my-feature`:
+
+```bash
+a() { bash .claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh "$@"; }
+
+# 1. Inspect the waves
+a waves
+
+# 2. Present the implementation split plan for human review
+a split-plan
+
+# --- HUMAN: review the table, edit agent/model assignments if needed,
+#     then say "approved" to proceed ---
+
+# 3. Fan out wave 1 (t1, t2, t3 are independent — run in parallel)
+git worktree add ../worktrees/agent-t1 -b agent/t1
+git worktree add ../worktrees/agent-t2 -b agent/t2
+git worktree add ../worktrees/agent-t3 -b agent/t3
+# ... spawn task agents in each worktree, await completion ...
+
+# 4. TDD-gated merge for each wave-1 task (no human per task)
+git merge --no-ff agent/t1   # tests pass before + after
+git worktree remove ../worktrees/agent-t1
+git merge --no-ff agent/t2
+git worktree remove ../worktrees/agent-t2
+git merge --no-ff agent/t3
+git worktree remove ../worktrees/agent-t3
+
+# 5. Advance to wave 2 (t4 depends on t1–t3 being merged)
+git worktree add ../worktrees/agent-t4 -b agent/t4
+# ... spawn, await, merge with TDD gate, remove worktree ...
+
+# 6. Open the final PR (human gate 3)
+bash .claude/skills/cicd/scripts/workflow.sh open
+```
+
+The exported plan-md from `devague plan export` is the standing brief for
+each task agent — its task id, summary, acceptance criteria, and the targets
+it covers are already in that file.
+
+## Provenance
+
+This is a **first-party** skill — its origin is `agentculture/devague`, where
+the devague agent maintains it alongside the tools it operates (dogfooding),
+next to its siblings `/think` and `/spec-to-plan`. It is the *third* skill in
+that outbound family, covering the implementation leg after a plan converges.
+The flow runs the *opposite* direction of the vendored steward skills: steward
+pulls this **from** devague and broadcasts it to the rest of the AgentCulture
+mesh. The `cite, don't import` policy still holds: downstream repos copy it,
+they don't symlink or depend on it. See `docs/skill-sources.md`.

--- a/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
+++ b/.claude/skills/assign-to-workforce/scripts/assign-to-workforce.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# assign-to-workforce.sh — fan out devague plan waves to parallel agents.
+#
+# The skill is named `assign-to-workforce`; it reads `devague plan waves`
+# (scheduling metadata produced by the /spec-to-plan skill) and renders the
+# implementation split plan: task map + per-task agent/model proposal + a
+# go/no-go prompt for the human. The actual fan-out (worktree creation,
+# spawning, TDD-gated merges) is performed by the operator/main agent once
+# the human approves the split plan.
+#
+# The devague CLI is non-orchestrating (#20): `devague plan waves` describes
+# the dependency graph; it does not spawn agents, manage worktrees, or pick
+# a backend. This wrapper is the operator-facing helper.
+#
+# Origin: authored and maintained in agentculture/devague. steward pulls this
+# skill from here and broadcasts it to the rest of the AgentCulture mesh, so
+# it is written to run anywhere — portable bash, no devague-checkout assumptions.
+#
+# Plans persist under .devague/ in the current directory, so run from the repo
+# you are implementing.
+
+set -euo pipefail
+
+# ── resolve the devague CLI (mesh-first, then local-dev fallback) ───────────
+DEVAGUE=()
+resolve_devague() {
+    if command -v devague >/dev/null 2>&1; then
+        DEVAGUE=(devague)            # installed tool — the normal mesh case
+        return 0
+    fi
+    # Local-dev fallback: inside the devague checkout, run via uv.
+    local dir="$PWD"
+    while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+        if [ -f "$dir/pyproject.toml" ] \
+            && grep -q '^name = "devague"' "$dir/pyproject.toml" 2>/dev/null; then
+            if command -v uv >/dev/null 2>&1; then
+                DEVAGUE=(uv run devague)
+                return 0
+            fi
+            break
+        fi
+        dir=$(dirname "$dir")
+    done
+    cat >&2 <<'EOF'
+error: devague CLI not found.
+hint: install it with `uv tool install devague` (or `pipx install devague`),
+      or run from inside the devague checkout with `uv` available.
+      https://github.com/agentculture/devague
+EOF
+    return 1
+}
+
+usage() {
+    cat <<'EOF'
+assign-to-workforce.sh — fan out devague plan waves to parallel agents.
+
+Usage:
+  assign-to-workforce.sh split-plan [--plan <slug>]   print the implementation split plan
+  assign-to-workforce.sh waves      [--plan <slug>] [--json]   list dependency waves
+  assign-to-workforce.sh help                         this help
+
+Commands:
+  split-plan   Read `devague plan waves --json` and render the human-facing
+               implementation split plan: task map + per-task agent/model
+               proposal + go/no-go. Present this to the human before any
+               fan-out; do not proceed without approval.
+  waves        Forward `devague plan waves` (and any extra flags) verbatim.
+               On a converged plan exits 0 and lists the dependency waves.
+
+Plans persist under .devague/ in the current directory — run from the repo
+you are implementing. Results go to stdout, diagnostics to stderr.
+
+Human gates (three only):
+  1. The exported spec (already closed by the /think leg).
+  2. This implementation split plan (go/no-go to assign to workforce).
+  3. The final PR (opened by the main agent via `cicd` / `devex pr open`).
+
+The devague CLI is non-orchestrating (#20): `devague plan waves` describes
+the graph; the operator performs the fan-out. One worktree per task; TDD
+gates every merge (tests pass before AND after merge); no human per task.
+EOF
+}
+
+# ── split-plan: render the implementation split plan for human review ────────
+cmd_split_plan() {
+    local extra_args=()
+    # Forward any --plan flag so waves targets the right plan.
+    while [ $# -gt 0 ]; do
+        extra_args+=("$1")
+        shift
+    done
+
+    local waves_json tmp_err waves_rc old_exit_trap
+    # Clean up the temp file on any exit path — including a signal after its
+    # creation — WITHOUT permanently changing the script's process-global EXIT
+    # handling. Capture any prior EXIT trap BEFORE mktemp (that capture forks a
+    # subshell, so doing it first keeps it out of the untracked-file window),
+    # then install our cleanup trap on the line immediately after mktemp, and
+    # restore the prior trap once the file is safely gone (#30; PR #31 review;
+    # devague#32).
+    old_exit_trap="$(trap -p EXIT)"
+    tmp_err="$(mktemp)"
+    trap 'rm -f "$tmp_err"' EXIT
+    set +e
+    waves_json="$("${DEVAGUE[@]}" plan waves --json "${extra_args[@]}" 2>"$tmp_err")"
+    waves_rc=$?
+    set -e
+    local waves_err
+    waves_err="$(cat "$tmp_err")"
+    rm -f "$tmp_err"
+    trap - EXIT
+    eval "${old_exit_trap}"  # empty string is a no-op; re-installs a prior trap if any
+
+    if [ "$waves_rc" -ne 0 ]; then
+        printf '%s\n' "$waves_err" >&2
+        return "$waves_rc"
+    fi
+
+    DEVAGUE_WAVES_JSON="$waves_json" python3 - <<'PY'
+import json
+import os
+import sys
+
+raw = os.environ.get("DEVAGUE_WAVES_JSON", "").strip()
+if not raw:
+    print("error: no waves output from devague plan waves", file=sys.stderr)
+    print("hint: ensure a converged plan exists (devague plan converge)", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    data = json.loads(raw)
+except json.JSONDecodeError as exc:
+    print(f"error: could not parse waves JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+plan_slug = data.get("plan", "(unknown)")
+waves = data.get("waves") or []
+
+print(f"Implementation split plan — plan: {plan_slug}")
+print()
+print("Dependency waves (from `devague plan waves`):")
+for i, wave in enumerate(waves, 1):
+    tasks = ", ".join(wave)
+    print(f"  Wave {i}: [{tasks}]")
+
+print()
+print("Task assignments (proposed — edit before approving):")
+print()
+
+headers = ("Task", "Wave", "Summary", "Agent type", "Model", "Scope note")
+rows = []
+for i, wave in enumerate(waves, 1):
+    for task_id in wave:
+        rows.append((
+            task_id,
+            str(i),
+            "(see plan export for summary + acceptance criteria)",
+            "subagent",
+            "cheaper/faster",
+            "TDD-scoped task; isolated worktree; tests gate merge",
+        ))
+
+col_widths = [max(len(h), max((len(r[j]) for r in rows), default=0))
+              for j, h in enumerate(headers)]
+
+def row_str(cells):
+    return "| " + " | ".join(c.ljust(w) for c, w in zip(cells, col_widths)) + " |"
+
+sep = "| " + " | ".join("-" * w for w in col_widths) + " |"
+print(row_str(headers))
+print(sep)
+for row in rows:
+    print(row_str(row))
+
+print()
+print("Go/no-go: review the table above, edit agent type / model / scope as needed,")
+print("then confirm: \"Approved — assign to workforce\" or \"Edit first\".")
+print()
+print("Once approved, fan out wave by wave:")
+print("  1. Create one git worktree per task in the wave.")
+print("  2. Spawn a task agent per worktree (brief = task summary + acceptance criteria).")
+print("  3. Await all tasks in the wave; then TDD-gate each merge (tests before + after).")
+print("  4. Advance to the next wave.")
+print("  5. Open the final PR (human gate 3) after all waves merge and tests pass.")
+PY
+}
+
+main() {
+    case "${1:-help}" in
+        help | -h | --help)
+            usage
+            return 0
+            ;;
+        split-plan)
+            shift
+            resolve_devague
+            cmd_split_plan "$@"
+            ;;
+        waves)
+            shift
+            resolve_devague
+            exec "${DEVAGUE[@]}" plan waves "$@"
+            ;;
+        *)
+            printf 'error: unknown subcommand: %s\n' "$1" >&2
+            printf 'hint: run `assign-to-workforce.sh help` for usage\n' >&2
+            return 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/.claude/skills/cicd/SKILL.md
+++ b/.claude/skills/cicd/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: cicd
+type: command
+description: >
+  reachy-mini-mcp's CI/CD lane, layered on `devex pr`. Delegates lint / open /
+  read / reply / delta to devex; adds two extensions — `status`
+  (SonarCloud quality gate + hotspots + unresolved-thread tally) and
+  `await` (read --wait + status with non-zero exit on Sonar ERROR or
+  unresolved threads). Use when: creating PRs in reachy-mini-mcp, handling
+  review feedback, polling CI status, or the user says "create PR",
+  "review comments", "address feedback", "resolve threads". Renamed
+  from `pr-review` in steward 0.7.0; rebased on devex in 0.12.0.
+---
+
+# CI/CD — reachy-mini-mcp edition
+
+`devex pr` (in `agentculture/devex`) is the upstream for the
+five core PR-lifecycle verbs — `lint`, `open`, `read`, `reply`,
+`delta`. Steward used to vendor parallel scripts for each; in 0.12.0
+those vendored copies were dropped in favor of delegating to `devex`.
+What's left in this skill is **the steward-specific gating layer**:
+
+- `status` — SonarCloud quality gate, OPEN issues, hotspots, deploy
+  preview URL, unresolved-inline-thread tally.
+- `await` — composes `devex pr read --wait` with `status` and gates on
+  Sonar `ERROR` / unresolved threads. The single command to run after
+  pushing a fix when you want "wake me when this PR is triage-able."
+
+Those two are the steward unique surface today. The `await` combo verb
+landed natively in devex
+([devex#41](https://github.com/agentculture/devex/issues/41), now
+closed); the gate extras that aren't yet native — SonarCloud hotspots,
+deploy-preview URL, an explicit resolved/unresolved thread tally — are
+tracked upstream in
+[devex#52](https://github.com/agentculture/devex/issues/52) and
+migrate out of this skill once they land.
+
+The workflow is encapsulated in `scripts/workflow.sh` — follow that
+(or call `devex pr` directly).
+
+## The devex inversion (upstream-as-consumer)
+
+One consumer is special: **devex itself**, the repo that owns `devex pr`.
+Vendoring this skill there verbatim would re-vendor bash that just wraps the
+Python devex already ships, so devex vendors it **adapted-thin**
+([devex#53](https://github.com/agentculture/devex/pull/53)):
+`workflow.sh` is the only script and it forwards
+`lint | open | read | reply | delta | await` straight to the native
+`devex pr <verb>` — including the native `devex pr await` combo verb (devex
+0.21.0). The steward `status` / `await` shell extensions and the vendored
+helpers (`pr-reply.sh`, `_resolve-nick.sh`, `portability-lint.sh`) are all
+redundant there, each superseded by a native verb. For that one consumer the
+skill collapses to a **pure delegate**.
+
+The only gate bits not yet native are SonarCloud **hotspots**, the
+**deploy-preview URL**, and an explicit **resolved/unresolved thread tally** —
+tracked upstream in
+[devex#52](https://github.com/agentculture/devex/issues/52). Once those
+land, steward retires `pr-status.sh` too and `workflow.sh status/await`
+delegates to native `devex pr` everywhere.
+
+**For broadcasts:** a skill-update brief to devex should expect this thin
+`workflow.sh`-only shape, not steward's five-file layout. (Ref:
+[steward#53](https://github.com/agentculture/steward/issues/53).)
+
+## Prerequisites
+
+Hard requirements: `devex` (>=0.21), `gh` (GitHub CLI), `jq`, `bash`,
+`python3` (stdlib only), `curl` (used by `pr-status.sh`).
+
+Install devex once:
+
+```bash
+uv tool install devex   # or: pip install --user devex
+```
+
+Soft requirement: `PyYAML` is needed **only for suffix mode** of the
+sibling `agent-config` skill, where it parses Culture's server
+manifest. Every `cicd` script works without it; suffix mode prints a
+clear install hint when invoked without it.
+
+Per-machine paths (sibling-project layout) live in
+`.claude/skills.local.yaml`; see the committed `.example` for the
+schema. `devex pr delta` reads the same file.
+
+## How to run
+
+`scripts/workflow.sh` is the entry point. Subcommands:
+
+| Command | What it does |
+|---------|--------------|
+| `workflow.sh lint` | `devex pr lint --exit-on-violation` — portability + alignment-trigger check. |
+| `workflow.sh open [gh-flags]` | `devex pr open --delayed-read`. Creates the PR, then polls 180s for an initial briefing. `--title TITLE` required; body via `--body-file PATH` or stdin. |
+| `workflow.sh read [PR] [--wait N]` | `devex pr read`. One-shot briefing (CI checks, SonarCloud gate + new issues, all comments, next-step footer). Pass `--wait N` to poll up to N seconds for required reviewers. |
+| `workflow.sh reply <PR>` | `devex pr reply <PR>` — batch JSONL replies (stdin) + thread resolve. devex auto-signs from `culture.yaml`. |
+| `workflow.sh delta` | `devex pr delta` — sibling alignment dump. |
+| `workflow.sh status <PR>` | **Steward extension.** `pr-status.sh` — Sonar gate, OPEN issues, hotspots, unresolved-thread breakdown, deploy preview URL. Authoritative gate for `await`. |
+| `workflow.sh await <PR>` | **Steward extension.** `devex pr read --wait` then `status`. Exits non-zero on Sonar ERROR or unresolved threads. Tunables: `STEWARD_PR_AWAIT_WAIT` (default 1800s passed to `--wait`), `STEWARD_PR_AWAIT_SECONDS` (legacy fixed pre-sleep, deprecated). |
+| `workflow.sh help` | Print the list. |
+
+You can also call `devex pr <verb>` directly — `workflow.sh` is a
+typing-saver around the same verbs. The steward `status` and `await`
+extensions only have shell entry points.
+
+The vendored single-comment helper `pr-reply.sh` (plus its
+`_resolve-nick.sh` dependency) is still shipped — pinned by
+`tests/test_pr_reply_signature.py` and `tests/test_resolve_nick.py`,
+and useful when a one-off reply doesn't merit batch JSONL. It is not
+called by `workflow.sh` anymore. The vendored `portability-lint.sh`
+is also still shipped — `steward doctor`'s portability check runs it
+directly against target repos. Both are scheduled for follow-up
+migration to devex.
+
+## Long waits (background polling)
+
+`devex pr read --wait N` polls in-session for up to N seconds. The
+Anthropic prompt cache has a 5-minute TTL; sleeping past it burns
+context every cache miss. Two ways to drive the wait:
+
+- **Synchronous** — `workflow.sh await <PR>` after `gh pr create` /
+  `workflow.sh open`. Fine when readiness is expected within ~5
+  minutes.
+- **Asynchronous** — for longer waits, run `devex pr read --wait NNN`
+  inside a background subagent (Agent tool, `run_in_background: true`)
+  so the main session only pays the cache cost when readiness fires.
+  The subagent's only job is to invoke `devex pr read --wait` and echo
+  its headline back. The parent triages with `workflow.sh await`
+  when the notification arrives. The user can interrupt with
+  TaskStop.
+
+This pattern was originally borrowed from sibling repo
+[`agentculture/cfafi`](https://github.com/agentculture/cfafi)'s `poll`
+skill. The async guidance is also filed upstream
+([devex#41](https://github.com/agentculture/devex/issues/41)).
+
+## Conventions
+
+`devex pr` emits a **"Next step:"** footer at the end of every command
+that names the right next verb (the same chain `devex learn cicd`
+documents) — follow that rather than memorizing an order. `workflow.sh
+help` mirrors the verb table when you need the steward-flavored
+extensions (`status`, `await`) on top.
+
+Branch naming: `fix/<desc>`, `feat/<desc>`, `docs/<desc>`,
+`skill/<name>`. PR / comment signature: `- <nick> (Claude)`, where
+`<nick>` is resolved by `devex` from the agent's own `culture.yaml`
+(first agent's `suffix`), falling back to the git-repo basename. devex
+auto-appends the signature on `pr open` and `pr reply` only when the
+body isn't already signed.
+
+## Finishing a branch
+
+When implementation on a branch is complete and tests pass, go straight
+to `workflow.sh open` (push the branch + open the PR). Do **not** stop to
+present a *merge / PR / keep / discard* menu and wait for a choice — in
+AgentCulture the standing default is **always "push and create a Pull
+Request."** This overrides the Superpowers `finishing-a-development-branch`
+skill's interactive menu, which otherwise pauses the flow at the moment
+work is ready to integrate. Merge-locally, keep-as-is, and discard happen
+only when the user explicitly asks for one of them.
+
+## Triage rules
+
+For every comment, decide **FIX** or **PUSHBACK** with reasoning.
+
+Default to **FIX** for: portability complaints (always valid for
+Steward — recurring bug class), test or doc requests, style nits
+aligned with workspace conventions.
+
+Default to **PUSHBACK** for: architecture opinions that conflict with
+workspace `CLAUDE.md` or the all-backends rule; greenfield
+false-positives (e.g. "add tests" before there's any source — defer
+to a later PR, don't refuse).
+
+### Alignment-delta rule
+
+If the PR touches `CLAUDE.md`, `culture.yaml`, or anything under
+`.claude/skills/`, run `workflow.sh delta` **before** declaring FIX or
+PUSHBACK on each comment. Note any sibling that needs a follow-up PR
+and mention it in your reply.
+
+## Greenfield-aware steps
+
+The lint and the workflow script are always-on. Stack-specific steps
+are conditional and currently no-op (greenfield repo):
+
+```bash
+[ -d tests ] && [ -f pyproject.toml ] && uv run pytest tests/ -x -q
+[ -f pyproject.toml ] && bump_version_per_project_convention   # see project README
+[ -f .markdownlint-cli2.yaml ] && markdownlint-cli2 "$(git diff --name-only --cached '*.md')"
+```
+
+Revisit each line as the corresponding stack element actually lands.
+A `pr lint --extra=tests,version,markdown` ask is filed upstream
+([devex#41](https://github.com/agentculture/devex/issues/41)).
+
+## Reply etiquette
+
+Every comment must get a reply — no silent fixes. `devex pr reply`
+includes thread-resolve by default. Reference the review-comment IDs
+in the fix-up commit message.
+
+The `status` extension queries SonarCloud directly (it predates the
+upstream Sonar integration in `devex pr read`). Both surfaces are
+trustworthy — `devex pr read` for display in the briefing, `status` for
+the gate. Steward isn't yet a registered mesh agent, so the
+post-merge IRC ping that Culture's `pr-review` includes is still
+skipped — that returns when Steward joins the mesh.

--- a/.claude/skills/cicd/scripts/_resolve-nick.sh
+++ b/.claude/skills/cicd/scripts/_resolve-nick.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve the agent's nick for GitHub message signing.
+# Order: first agent's `suffix` in <repo-root>/culture.yaml,
+# then basename of the git repo root.
+# Prints the nick to stdout. Always exits 0 — pr-reply.sh needs *some*
+# nick to sign with — but if a culture.yaml exists and we couldn't
+# extract a suffix from it, emits a stderr warning so a misconfigured
+# manifest doesn't silently mask itself behind the basename fallback.
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$repo_root" ]]; then
+    repo_root="$PWD"
+fi
+
+manifest="$repo_root/culture.yaml"
+
+if [[ -f "$manifest" ]]; then
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "_resolve-nick: python3 not found; cannot parse $manifest, falling back to repo basename" >&2
+    else
+        nick="$(python3 - "$manifest" <<'PY' 2>/dev/null || true
+import re, sys
+path = sys.argv[1]
+with open(path, encoding="utf-8") as f:
+    for raw in f:
+        line = raw.rstrip("\n")
+        m = re.match(r"^[\s-]*\s*suffix:\s*(\S+)", line)
+        if m:
+            print(m.group(1).strip("'\""))
+            break
+PY
+)"
+        if [[ -n "$nick" ]]; then
+            printf '%s\n' "$nick"
+            exit 0
+        fi
+        echo "_resolve-nick: $manifest exists but no suffix could be parsed; falling back to repo basename" >&2
+    fi
+fi
+
+basename "$repo_root"

--- a/.claude/skills/cicd/scripts/portability-lint.sh
+++ b/.claude/skills/cicd/scripts/portability-lint.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Portability lint: catch path leaks and per-user config dependencies in
+# committed docs/configs before they ship in a PR. Steward's recurring bug
+# class.
+#
+# Usage: portability-lint.sh [--all]
+#   default: lint files modified vs HEAD (staged + unstaged)
+#   --all:   lint all tracked files
+#
+# Exits 0 if clean, 1 if any leak is found.
+
+set -euo pipefail
+
+mode="${1:-diff}"
+case "$mode" in
+    --all) files=$(git ls-files -- ':(exclude)*.lock') ;;
+    diff|--diff) files=$(git diff --diff-filter=AMR --name-only HEAD -- ':(exclude)*.lock') ;;
+    *) echo "Usage: $(basename "$0") [--all]" >&2; exit 2 ;;
+esac
+
+[ -z "$files" ] && { echo "(no files to check)"; exit 0; }
+
+# ----- Check 1: hard-coded /home/<user>/... paths -----
+hits1=$(echo "$files" | xargs -r grep -nE '/home/[a-z][a-z0-9_-]+/' 2>/dev/null || true)
+
+# ----- Check 2: per-user dotfile *config* refs in committed docs/configs -----
+# Carve-outs (allowed, NOT flagged):
+#   - ~/.claude/skills/<x>/scripts/   vendored tool calls
+#   - ~/.culture/                     Culture mesh data this skill is supposed to read
+md_yaml=$(echo "$files" | grep -E '\.(md|ya?ml|toml|json|jsonc)$' || true)
+if [ -n "$md_yaml" ]; then
+    hits2=$(echo "$md_yaml" | xargs -r grep -nE '~/\.[A-Za-z]' 2>/dev/null \
+        | grep -vE '~/\.claude/skills/[^[:space:]"]+/scripts/' \
+        | grep -vE '~/\.culture/' \
+        || true)
+else
+    hits2=""
+fi
+
+fail=0
+if [ -n "$hits1" ]; then
+    echo "❌ Hard-coded /home/<user>/ paths:"
+    echo "$hits1" | sed 's/^/    /'
+    echo "   Fix: use ../sibling, repo URL, or \$WORKSPACE/sibling instead."
+    fail=1
+fi
+if [ -n "$hits2" ]; then
+    [ "$fail" -eq 1 ] && echo
+    echo "❌ Per-user ~/.<dotfile> config refs in committed doc/config:"
+    echo "$hits2" | sed 's/^/    /'
+    echo "   Allowed carve-outs: ~/.claude/skills/.../scripts/ (tool calls), ~/.culture/ (mesh data)."
+    echo "   Otherwise: commit a repo-local config or document a portable lookup."
+    fail=1
+fi
+
+[ "$fail" -eq 0 ] && echo "✓ portability lint clean ($(echo "$files" | wc -l | tr -d ' ') files checked)"
+exit $fail

--- a/.claude/skills/cicd/scripts/pr-reply.sh
+++ b/.claude/skills/cicd/scripts/pr-reply.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reply to a PR review comment, optionally resolve its thread.
+# Usage: pr-reply.sh [--repo OWNER/REPO] [--resolve] PR_NUMBER COMMENT_ID "body"
+
+REPO=""
+RESOLVE=false
+PRINT_BODY=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --resolve) RESOLVE=true; shift ;;
+        --print-body) PRINT_BODY=true; shift ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-reply.sh [--repo OWNER/REPO] [--resolve] [--print-body] PR_NUMBER COMMENT_ID \"body\"}"
+COMMENT_ID="${2:?Missing COMMENT_ID}"
+BODY="${3:?Missing reply body}"
+
+if [[ "$PRINT_BODY" != true && -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+
+# Sign with the agent's nick. Resolved per invocation so siblings that
+# vendor this skill pick up their own culture.yaml suffix automatically.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NICK="$("$SCRIPT_DIR/_resolve-nick.sh")"
+SIG="- ${NICK} (Claude)"
+if ! printf '%s' "$BODY" | grep -qFx -- "$SIG"; then
+    BODY="${BODY}
+
+${SIG}"
+fi
+
+if [[ "$PRINT_BODY" == true ]]; then
+    printf '%s\n' "$BODY"
+    exit 0
+fi
+
+# Post reply
+REPLY_URL=$(gh api "repos/$REPO/pulls/$PR_NUMBER/comments/$COMMENT_ID/replies" \
+    -f body="$BODY" \
+    --jq '.html_url')
+echo "Replied: $REPLY_URL"
+
+# Resolve thread if requested
+if [[ "$RESOLVE" == true ]]; then
+    # Find the thread ID for this comment
+    THREAD_ID=$(gh api graphql -f query="
+    {
+      repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+        pullRequest(number: $PR_NUMBER) {
+          reviewThreads(first: 100) {
+            nodes {
+              id
+              comments(first: 100) {
+                nodes { databaseId }
+              }
+            }
+          }
+        }
+      }
+    }" --jq ".data.repository.pullRequest.reviewThreads.nodes[] | select(any(.comments.nodes[]; .databaseId == $COMMENT_ID)) | .id")
+
+    if [[ -n "$THREAD_ID" ]]; then
+        RESOLVED=$(gh api graphql -f query="
+          mutation { resolveReviewThread(input: {threadId: \"$THREAD_ID\"}) { thread { isResolved } } }
+        " --jq '.data.resolveReviewThread.thread.isResolved')
+        echo "Resolved: $RESOLVED (thread $THREAD_ID)"
+    else
+        echo "Warning: could not find thread for comment $COMMENT_ID"
+    fi
+fi

--- a/.claude/skills/cicd/scripts/pr-status.sh
+++ b/.claude/skills/cicd/scripts/pr-status.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# pr-status.sh — one-shot status overview for a Steward PR.
+#
+# Combines five things review feedback usually scatters across:
+#   1. PR state (open / merged / closed) + branch + author
+#   2. CI checks (build / lint / unit / sonarcloud / cf-pages / etc.)
+#   3. Review-bot pipeline status (Copilot, qodo, SonarCloud, Cloudflare)
+#   4. SonarCloud quality gate + open-issue count
+#   5. Inline-thread resolved-vs-unresolved tally
+#
+# Usage: scripts/pr-status.sh [--repo OWNER/REPO] [--sonar-key KEY] PR_NUMBER
+#
+# Defaults:
+#   --repo           auto-detected via `gh repo view`
+#   --sonar-key      derived from repo as `<owner>_<name>` (SonarCloud convention)
+#
+# Requires: gh, jq, curl, python3.
+
+set -euo pipefail
+
+REPO=""
+SONAR_KEY=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) REPO="$2"; shift 2 ;;
+        --sonar-key) SONAR_KEY="$2"; shift 2 ;;
+        *) break ;;
+    esac
+done
+
+PR_NUMBER="${1:?Usage: pr-status.sh [--repo OWNER/REPO] [--sonar-key KEY] PR_NUMBER}"
+
+if [[ -z "$REPO" ]]; then
+    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+fi
+# Sonar key precedence: explicit --sonar-key flag > SONAR_PROJECT_KEY env >
+# `<owner>_<repo>` derivation. Mirrors pr-comments.sh so SKILL.md's claim
+# that the env var works for both scripts is true.
+if [[ -z "$SONAR_KEY" ]]; then
+    SONAR_KEY="${SONAR_PROJECT_KEY:-${REPO%%/*}_${REPO##*/}}"
+fi
+
+# ── 1. PR header ──────────────────────────────────────────────────────────
+PR_JSON=$(gh pr view "$PR_NUMBER" --json \
+    number,title,state,isDraft,mergedAt,mergedBy,baseRefName,headRefName,author,url)
+
+echo "════════════════════════════════════════════════════════════════════"
+echo "$PR_JSON" | jq -r '
+    "PR #\(.number) — \(.title)",
+    "  \(.url)",
+    "  Author:  \(.author.login)",
+    "  Branch:  \(.headRefName)  →  \(.baseRefName)",
+    "  State:   \(if .state == "MERGED" then "MERGED at \(.mergedAt) by \(.mergedBy.login)" elif .state == "OPEN" and .isDraft then "OPEN (draft)" else .state end)"
+'
+echo "════════════════════════════════════════════════════════════════════"
+
+# ── 2. CI checks ──────────────────────────────────────────────────────────
+echo
+echo "── CI checks ─────────────────────────────────────────────────────────"
+# `gh pr checks` exits non-zero when checks are still pending/failing.
+# We don't care about its exit code here; capture and pretty-print.
+CHECKS=$(gh pr checks "$PR_NUMBER" 2>/dev/null || true)
+if [[ -z "$CHECKS" ]]; then
+    echo "  (no checks reported)"
+else
+    echo "$CHECKS" | awk -F'\t' '
+        {
+            name  = $1
+            state = $2
+            dur   = $3
+            sym   = "?"
+            if (state == "pass")            sym = "✅"
+            else if (state == "fail")       sym = "❌"
+            else if (state == "skipping")   sym = "⏭"
+            else if (state == "pending"  || state == "queued"   || state == "in_progress") sym = "…"
+            printf "  %s %-22s %-10s %s\n", sym, name, state, dur
+        }
+    '
+fi
+
+# ── 3. Review bots & comment pipeline ────────────────────────────────────
+echo
+echo "── Review pipeline ───────────────────────────────────────────────────"
+
+# Inline-thread tally via GraphQL (resolved vs unresolved).
+THREADS_JSON=$(gh api graphql -f query="
+{
+  repository(owner: \"${REPO%%/*}\", name: \"${REPO##*/}\") {
+    pullRequest(number: $PR_NUMBER) {
+      reviewThreads(first: 100) {
+        nodes { id isResolved comments(first: 1) { nodes { author { login } } } }
+      }
+    }
+  }
+}" --jq '.data.repository.pullRequest.reviewThreads.nodes')
+
+INLINE_TOTAL=$(echo "$THREADS_JSON" | jq 'length')
+INLINE_RESOLVED=$(echo "$THREADS_JSON" | jq '[.[] | select(.isResolved)] | length')
+INLINE_PENDING=$((INLINE_TOTAL - INLINE_RESOLVED))
+
+# Per-bot inline counts.
+COPILOT_INLINE=$(echo "$THREADS_JSON" | jq '[.[] | select((.comments.nodes[0].author.login // "") | startswith("Copilot"))] | length')
+QODO_INLINE=$(echo "$THREADS_JSON" | jq '[.[] | select((.comments.nodes[0].author.login // "") | startswith("qodo"))] | length')
+
+# Issue-level comments (qodo summary, sonarcloud quality-gate body, cf-pages preview, etc.).
+# Skip --paginate to avoid array concatenation; per_page=100 covers typical PRs.
+ISSUE=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100")
+QODO_ISSUE=$(echo "$ISSUE" | jq '[.[] | select((.user.login // "") | startswith("qodo"))] | length')
+SONARQUBE_ISSUE=$(echo "$ISSUE" | jq '[.[] | select((.user.login // "") | startswith("sonarqubecloud"))] | length')
+CFPAGES_ISSUE=$(echo "$ISSUE" | jq '[.[] | select((.user.login // "") | test("cloudflare"))] | length')
+COPILOT_TOPLEVEL=$(gh api "repos/$REPO/pulls/$PR_NUMBER/reviews?per_page=100" \
+    | jq '[.[] | select((.user.login // "") | startswith("copilot")) | select((.body // "") != "")] | length')
+
+# Cloudflare deploy URL hidden in issue-comment bodies (look for pages.dev).
+CF_URL=$(echo "$ISSUE" | jq -r '[.[].body // "" | scan("https?://[a-z0-9.-]+\\.pages\\.dev[^\\s)\"<]*")] | first // ""')
+
+printf "  %-12s %s\n"  "Copilot"     "$([[ "$COPILOT_TOPLEVEL" -gt 0 || "$COPILOT_INLINE" -gt 0 ]] && echo "✅ overview×$COPILOT_TOPLEVEL, inline×$COPILOT_INLINE" || echo "— no posts yet")"
+printf "  %-12s %s\n"  "qodo"        "$([[ "$QODO_ISSUE" -gt 0 || "$QODO_INLINE" -gt 0 ]] && echo "✅ summary×$QODO_ISSUE, inline×$QODO_INLINE" || echo "— no posts yet")"
+printf "  %-12s %s\n"  "Cloudflare"  "$([[ -n "$CF_URL" ]] && echo "✅ $CF_URL" || ([[ "$CFPAGES_ISSUE" -gt 0 ]] && echo "✅ ($CFPAGES_ISSUE comments)" || echo "— no deploy preview"))"
+
+# ── 4. SonarCloud quality gate + open issues ─────────────────────────────
+SONAR_QG=$(curl -s "https://sonarcloud.io/api/qualitygates/project_status?projectKey=${SONAR_KEY}&pullRequest=${PR_NUMBER}")
+SONAR_QG_STATUS=$(echo "$SONAR_QG" | jq -r '.projectStatus.status // "UNKNOWN"')
+SONAR_OPEN=$(curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_KEY}&pullRequest=${PR_NUMBER}&statuses=OPEN,CONFIRMED&ps=1" \
+    | jq -r '.total // 0')
+SONAR_HOTSPOTS=$(curl -s "https://sonarcloud.io/api/hotspots/search?projectKey=${SONAR_KEY}&pullRequest=${PR_NUMBER}&status=TO_REVIEW&ps=1" \
+    | jq -r '.paging.total // 0')
+
+case "$SONAR_QG_STATUS" in
+    OK)    SONAR_SYM="✅" ;;
+    ERROR) SONAR_SYM="❌" ;;
+    WARN)  SONAR_SYM="⚠ " ;;
+    *)     SONAR_SYM="?" ;;
+esac
+printf "  %-12s %s Quality Gate %s, %d OPEN issue(s), %d hotspot(s)\n" \
+    "SonarCloud" "$SONAR_SYM" "$SONAR_QG_STATUS" "$SONAR_OPEN" "$SONAR_HOTSPOTS"
+
+# When SonarCloud has OPEN issues, list them — saves a follow-up curl.
+if [[ "$SONAR_OPEN" != "0" ]]; then
+    echo
+    echo "  SonarCloud OPEN issues:"
+    curl -s "https://sonarcloud.io/api/issues/search?componentKeys=${SONAR_KEY}&pullRequest=${PR_NUMBER}&statuses=OPEN,CONFIRMED&ps=20" \
+        | jq -r '.issues[] | "    • [\(.rule)] \(.component | sub("^[^:]+:"; ""))(:\(.line // "?")) (\(.severity)) — \(.message)"'
+fi
+
+# ── 5. Tally + summary ────────────────────────────────────────────────────
+echo
+echo "── Inline threads ────────────────────────────────────────────────────"
+printf "  Total: %d   Resolved: %d   Unresolved: %d\n" \
+    "$INLINE_TOTAL" "$INLINE_RESOLVED" "$INLINE_PENDING"
+
+if [[ "$INLINE_PENDING" -gt 0 ]]; then
+    echo
+    echo "  Unresolved threads:"
+    echo "$THREADS_JSON" | jq -r '
+        .[] | select(.isResolved == false) |
+        "    • \(.comments.nodes[0].author.login): thread \(.id)"
+    '
+fi
+
+echo
+echo "(For full comment bodies: devex pr read --agent claude-code $PR_NUMBER)"

--- a/.claude/skills/cicd/scripts/workflow.sh
+++ b/.claude/skills/cicd/scripts/workflow.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Steward cicd workflow — thin layer over `devex pr` plus two steward
+# extensions (`status`, `await`) for SonarCloud gating and triage flow.
+#
+# Subcommands:
+#   lint                   `devex pr lint --exit-on-violation`. Same rules
+#                          steward used to vendor in portability-lint.sh
+#                          (which still ships for `steward doctor`).
+#   open  [gh-pr flags]    `devex pr open --delayed-read "$@"`. Creates the
+#                          PR, then polls 180s for an initial briefing.
+#                          Body via --body-file PATH or stdin; --title is
+#                          required.
+#   read  [PR] [--wait N]  `devex pr read "$@"`. One-shot briefing today;
+#                          pass --wait N to poll for reviewer readiness.
+#                          Covers what create-pr-and-wait / pr-comments /
+#                          wait-and-check / poll-readiness used to do.
+#   reply <PR>             `devex pr reply <PR>` (JSONL on stdin). devex
+#                          auto-signs from culture.yaml; same JSONL
+#                          shape as the old pr-batch.sh.
+#   delta                  `devex pr delta`. Sibling alignment dump.
+#
+#   status <PR>            Steward extension: pr-status.sh — SonarCloud
+#                          gate, OPEN issues, hotspots, unresolved
+#                          inline-thread tally, deploy-preview URL.
+#                          Source of truth for the `await` gate.
+#   await  <PR>            Steward extension: `read --wait` for the
+#                          briefing, then `status` for the gate. Exits
+#                          non-zero on SonarCloud ERROR or unresolved
+#                          threads. Tunables:
+#                            STEWARD_PR_AWAIT_WAIT (default 1800)
+#                              — seconds passed to `read --wait`.
+#                            STEWARD_PR_AWAIT_SECONDS (legacy)
+#                              — fixed pre-sleep, deprecated.
+#
+#   help                   print this message
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# devex's `--agent` flag accepts only claude-code|codex|copilot|acp. The
+# workspace culture.yaml convention is `backend: claude`, so we always
+# pass --agent explicitly to insulate steward from that naming gap.
+# Override via STEWARD_DEVEX_AGENT if you're running under codex/copilot/acp.
+DEVEX_AGENT="${STEWARD_DEVEX_AGENT:-claude-code}"
+
+require_devex() {
+    if ! command -v devex >/dev/null 2>&1; then
+        echo "✗ devex not on PATH. Install devex (>=0.21)." >&2
+        echo "  uv tool install devex  # or pip install devex" >&2
+        exit 2
+    fi
+}
+
+cmd="${1:-help}"
+shift || true
+
+case "$cmd" in
+    lint)
+        require_devex
+        exec devex pr lint --agent "$DEVEX_AGENT" --exit-on-violation "$@"
+        ;;
+    open)
+        require_devex
+        exec devex pr open --agent "$DEVEX_AGENT" --delayed-read "$@"
+        ;;
+    read)
+        require_devex
+        exec devex pr read --agent "$DEVEX_AGENT" "$@"
+        ;;
+    reply)
+        require_devex
+        PR="${1:?Usage: workflow.sh reply <PR>  (JSONL on stdin)}"
+        exec devex pr reply --agent "$DEVEX_AGENT" "$PR"
+        ;;
+    delta)
+        require_devex
+        exec devex pr delta --agent "$DEVEX_AGENT" "$@"
+        ;;
+    status)
+        PR="${1:?Usage: workflow.sh status <PR>}"
+        exec bash "$SCRIPT_DIR/pr-status.sh" "$PR"
+        ;;
+    await)
+        require_devex
+        PR="${1:?Usage: workflow.sh await <PR>}"
+
+        # Legacy fixed-sleep escape hatch.
+        if [ -n "${STEWARD_PR_AWAIT_SECONDS:-}" ]; then
+            echo "warning: STEWARD_PR_AWAIT_SECONDS is deprecated; prefer STEWARD_PR_AWAIT_WAIT." >&2
+            echo "→ sleeping ${STEWARD_PR_AWAIT_SECONDS}s (legacy fixed-sleep) before devex pr read …" >&2
+            sleep "$STEWARD_PR_AWAIT_SECONDS"
+            WAIT_ARGS=()
+        else
+            WAIT="${STEWARD_PR_AWAIT_WAIT:-1800}"
+            WAIT_ARGS=(--wait "$WAIT")
+        fi
+
+        # 1. devex pr read --wait — readiness loop + briefing.
+        # Capture rc from the command itself (not from the negated test —
+        # `if ! cmd; then rc=$?` would store the if-test status, always 0
+        # in the failure branch, masking the real exit code).
+        echo "── devex pr read ──────────────────────────────────────────────────────" >&2
+        if devex pr read --agent "$DEVEX_AGENT" "$PR" "${WAIT_ARGS[@]}"; then
+            READ_RC=0
+        else
+            READ_RC=$?
+        fi
+        if [ "$READ_RC" -ne 0 ]; then
+            echo "✗ devex pr read failed (exit $READ_RC)" >&2
+            exit "$READ_RC"
+        fi
+
+        # 2. pr-status.sh — authoritative gate (Sonar QG, unresolved threads).
+        echo >&2
+        echo "── pr-status ─────────────────────────────────────────────────────────" >&2
+        if STATUS_OUT=$(bash "$SCRIPT_DIR/pr-status.sh" "$PR" 2>&1); then
+            STATUS_RC=0
+        else
+            STATUS_RC=$?
+        fi
+        printf '%s\n' "$STATUS_OUT"
+        if [ "$STATUS_RC" -ne 0 ]; then
+            echo >&2
+            echo "✗ pr-status.sh failed (exit $STATUS_RC) — cannot determine PR state" >&2
+            exit "$STATUS_RC"
+        fi
+
+        # 3. Gate. Markers in pr-status.sh output:
+        #     "Quality Gate ERROR"          → Sonar fail
+        #     "Unresolved: N" with N>0      → unresolved threads
+        SONAR_FAIL=0
+        UNRESOLVED=0
+        if printf '%s\n' "$STATUS_OUT" | grep -qE 'Quality Gate ERROR'; then
+            SONAR_FAIL=1
+        fi
+        if PENDING=$(printf '%s\n' "$STATUS_OUT" | grep -oE 'Unresolved:[[:space:]]+[0-9]+' | grep -oE '[0-9]+$' | head -1); then
+            [ -n "${PENDING:-}" ] && [ "$PENDING" -gt 0 ] && UNRESOLVED=1
+        fi
+        if [ "$SONAR_FAIL" -eq 1 ] || [ "$UNRESOLVED" -eq 1 ]; then
+            echo >&2
+            [ "$SONAR_FAIL" -eq 1 ] && echo "✗ SonarCloud quality gate ERROR" >&2
+            [ "$UNRESOLVED" -eq 1 ] && echo "✗ ${PENDING} unresolved review thread(s)" >&2
+            exit 1
+        fi
+        echo >&2
+        echo "✓ no SonarCloud ERROR, no unresolved threads" >&2
+        ;;
+    help|--help|-h)
+        sed -n '4,38p' "${BASH_SOURCE[0]}" | sed 's/^# *//'
+        ;;
+    *)
+        echo "unknown subcommand: $cmd" >&2
+        echo "run '$(basename "$0") help' for usage." >&2
+        exit 2
+        ;;
+esac

--- a/.claude/skills/communicate/SKILL.md
+++ b/.claude/skills/communicate/SKILL.md
@@ -1,0 +1,336 @@
+---
+name: communicate
+type: command
+description: >
+  Cross-repo + mesh communication from reachy-mini-mcp: file tracked GitHub issues
+  on sibling repos, fetch issues from sibling repos to inline current state
+  into briefs, and send live messages to Culture mesh channels. Use when
+  the next step lives outside reachy-mini-mcp (a brief for a sibling-repo agent, a
+  status ping for a Culture channel, or pulling an issue body + comments
+  into context). Issue posts auto-sign with `- reachy-mini-mcp (Claude)`; mesh
+  messages are unsigned (the IRC nick is the speaker). Not for in-reachy-mini-mcp
+  issues — use `gh issue create` or the `cicd` skill for those. Renamed
+  from `coordinate` in steward 0.8.0; absorbed `gh-issues` in 0.9.1.
+  Issue I/O is backed by `agtag` (>=0.1) starting in 0.11.0.
+---
+
+# Communicate (Cross-Repo + Mesh)
+
+Steward's job is alignment across the AgentCulture mesh; that surfaces in
+four distinct channels:
+
+- **Tracked, async hand-offs** — a gap in another repo (a missing public
+  API, a divergent skill, a documentation ask) where an agent on the
+  other side needs to act, and the ask should outlive the conversation.
+  → `post-issue.sh` (GitHub).
+- **Follow-up on a tracked thread** — a status update, an answer to a
+  question, or a "this is done" note on an issue that's already open.
+  → `post-comment.sh` (GitHub).
+- **Inbound state read** — pulling current issue body + comments from a
+  sibling repo so a brief or plan can inline what's there instead of
+  saying "see issue #N." → `fetch-issues.sh` (GitHub).
+- **Ephemeral coordination** — a status ping, a question, a "PR ready
+  for merge" notice on a Culture mesh channel where the audience is
+  already listening.
+  → `mesh-message.sh` (Culture IRC).
+
+All four live under one skill because they share the same audience
+(sibling-repo agents) and the same red flag (don't double-post the same
+ask across post + mesh — pick one).
+
+## Backed by agtag
+
+The three GitHub verbs (`post-issue.sh`, `post-comment.sh`,
+`fetch-issues.sh`) are thin wrappers around the `agtag` CLI
+(`agtag issue post|reply|fetch`). agtag handles auto-signature
+resolution from the local `culture.yaml` (falling back to repo
+basename), JSON output mode, and a uniform exit-code policy. Read
+`agtag learn` for the agent-facing self-teaching prompt and
+`agtag explain agtag` / `agtag explain issue` for the surface docs —
+this SKILL.md does not re-document agtag's flags.
+
+`mesh-message.sh` stays a `culture channel message` wrapper for now;
+agtag mesh transport is slated for v0.2.
+
+## When to Use
+
+### Issue mode (`post-issue.sh`)
+
+- A gap surfaces in **another repo's surface** (missing public API,
+  wire-format compat fix, divergent skill, documentation ask).
+- You're handing off a self-contained brief to a sibling-repo agent.
+- **(steward-specific — supplier role.)** You're **onboarding a sibling to the
+  stack** — "set it up", "align it", "update it with our stack", "set up the
+  pipelines". The deliverable is an issue with a self-contained brief, **never
+  files written into that repo**. In steward, quote steward's
+  `docs/sibling-pattern.md` (required artifacts) and `docs/skill-sources.md`
+  (the skill set to vendor) into the brief so it stands alone; steward's
+  `CLAUDE.md` "Steward's lane" section is the canonical statement. Downstream
+  vendors of this skill don't onboard siblings — those steward-side docs don't
+  exist in your repo, so skip this bullet.
+- You're asking a question that benefits from a tracked artifact rather
+  than ephemeral chat.
+
+### Broadcast mode (`steward announce-skill-update`)
+
+- You bumped a skill in `.claude/skills/<name>/` and the change is
+  more than identifier-only or doc-only — downstream consumers will
+  benefit from re-vendoring.
+- Don't hand-author the brief — the `steward announce-skill-update`
+  verb (steward-cli) renders the canonical six-section form (what's
+  stale, cite locations, what's in upstream now, recipe, acceptance
+  criteria, references) from the live state of
+  `.claude/skills/<name>/scripts/`, the `CHANGELOG.md`, and
+  `docs/skill-sources.md`'s downstream column. Then it pipes through
+  this skill's `post-issue.sh` per consumer (so the auto-signature
+  stays consistent with hand-authored briefs).
+
+### Mesh mode (`mesh-message.sh`)
+
+- You want to ping a Culture channel with a status update ("PR #N ready
+  for merge", "starting nightly corpus scan").
+- You're asking a question where you expect a fast reply from whoever
+  is listening on the channel right now.
+- You're announcing a decision that doesn't need a tracked artifact.
+
+### Comment mode (`post-comment.sh`)
+
+- An open issue needs a follow-up — a status update, an answer to a
+  maintainer's question, a "this is shipped" note pointing at a PR.
+- You're closing the loop on an `agtag issue post` you sent earlier and
+  the resolution belongs on the same thread (audit trail beats a
+  separate ping).
+- Auto-signed by agtag; do not hand-author the trailing nick.
+
+### Fetch mode (`fetch-issues.sh`)
+
+- You're about to write a brief and want to inline the current state of
+  one or more sibling-repo issues (body + comments) instead of saying
+  "see issue #N."
+- You're triaging a list of cross-repo issues and want their bodies and
+  comments in one shot for context.
+- Avoids the `gh issue view` "Projects (classic) deprecated" error by
+  passing `--json` explicitly to GitHub.
+
+## When NOT to Use
+
+- **In-steward issues** — open them with `gh issue create` directly, or
+  work them through the `cicd` skill.
+- **PR review comments** — that's the `cicd` skill (which already
+  auto-signs replies).
+- **Routine commits** — those don't get cross-repo signatures.
+- **Long-form asks on the mesh** — anything that needs acceptance
+  criteria belongs in an issue, not a channel message.
+
+## Conventions
+
+### 1. Briefs are self-contained
+
+The receiving agent must not need steward-side context to act. Inline
+the relevant content; do not say "see steward's plan."
+
+A brief that says "see steward#NN" is a bug. The receiving agent will
+look at it, get lost in steward-specific context that's irrelevant to
+them, and either ask for clarification (slow round-trip) or guess wrong
+(worse). Inline the ask, the rationale, and concrete acceptance
+criteria. Quote source-of-truth files (path + line numbers + small
+excerpts) when their shape matters to the ask.
+
+### 2. Per-channel signature rules
+
+| Channel | Signature | Why |
+|---------|-----------|-----|
+| GitHub issues / comments | `- <nick> (Claude)` — agtag resolves `<nick>` from the local `culture.yaml`, falling back to repo basename | Cross-repo audit trail — readers can tell at a glance which sibling and that it came from an AI. |
+| Culture mesh | none — unsigned | The IRC nick already identifies the speaker. A trailing `- <nick> (Claude)` would be visual noise that the nick already supplies. |
+
+Vendors do not need to edit a literal — agtag does the resolution.
+`--as NICK` overrides if a vendor needs to sign as something other than
+its `culture.yaml` suffix. Mesh messages stay unsigned across all
+vendors.
+
+### 3. Issue title format
+
+`<verb> <thing> (unblocks <consumer>)` — e.g.,
+`Vendor portability-lint into <repo> (unblocks steward 0.7 doctor --apply)`.
+The parenthetical tells the receiving repo's maintainers what's waiting
+on them. Drop the parenthetical only when the ask isn't blocking
+anything.
+
+## How to Invoke
+
+### File a new issue
+
+```bash
+bash .claude/skills/communicate/scripts/post-issue.sh \
+    --repo agentculture/<sibling> \
+    --title "Vendor portability-lint into <sibling> (unblocks steward 0.7)" \
+    --body-file /tmp/brief.md
+```
+
+Or pass the body on stdin:
+
+```bash
+bash .claude/skills/communicate/scripts/post-issue.sh \
+    --repo agentculture/<sibling> \
+    --title "..." <<'EOF'
+<brief body here, multi-paragraph, with all the inline context the receiving agent needs>
+EOF
+```
+
+The script prints the issue URL on success — capture it for
+cross-references in your spec / plan / PR description. agtag appends
+the signature `- <nick> (Claude)` (resolved from `culture.yaml`).
+
+### Broadcast a skill update to known consumers
+
+This is steward's role specifically — the verb lives in `steward-cli`,
+not in this skill's `scripts/`. Downstream vendors of `communicate`
+(cfafi, culture, auntiepypi, …) do not get a broadcast wrapper because
+they don't broadcast — they only use the primitives above
+(`post-issue.sh`, `fetch-issues.sh`, `mesh-message.sh`).
+
+```bash
+# Default: read consumers from docs/skill-sources.md "Downstream copies"
+# cell for <skill>; render the six-section brief; pipe to post-issue.sh
+# for each consumer.
+steward announce-skill-update --skill cicd --since 0.6.0
+
+# Override the consumer list (skips the ledger lookup entirely):
+steward announce-skill-update --skill cicd \
+    --to agentculture/auntiepypi --to agentculture/cfafi
+
+# Preview without posting:
+steward announce-skill-update --skill cicd \
+    --to agentculture/auntiepypi --dry-run
+
+# Just print the consumer list (for ledger sanity-checks):
+steward announce-skill-update --skill cicd --list
+```
+
+`--since VERSION` controls which CHANGELOG entries get inlined (every
+entry from the top down to but not including the cutoff version).
+Without it, the verb keyword-filters CHANGELOG entries to those
+mentioning the skill name. `--note-file PATH` appends free-text under
+the upstream script list for skill-specific gotchas the generic
+template can't anticipate (e.g. "this skill's `post-issue.sh`
+hard-codes a signature literal — your vendor must change it"). The
+brief is rendered once and reused across consumers; per-consumer
+failures stream to stderr and the verb exits 1 if any failed. The
+template lives at
+`scripts/templates/skill-update-brief.md` so future supplier-role
+repos can render their own briefs from the same shape.
+
+#### Fast recipe — "brief sibling-repo Z on skill X"
+
+This shape of ask is a recipe, not a planning question. Skip plan
+mode. The call site:
+
+```bash
+steward announce-skill-update \
+    --skill <name> --to <owner>/<repo> \
+    --since <last-stable-version> \
+    [--note-file /tmp/note.md] --dry-run
+```
+
+Eyeball the rendered brief; drop `--dry-run` to post. The verb
+prints the issue URL on success and exits non-zero on failure —
+that is the verification. Don't write parallel `gh issue list` /
+`gh issue view` checks unless the verb itself is what you're
+testing. `--to` overrides the ledger, so non-ledger consumers
+don't require a ledger edit first; they enter the ledger later
+when they confirm their vendored shape.
+
+### Comment on an existing issue
+
+```bash
+bash .claude/skills/communicate/scripts/post-comment.sh \
+    --repo agentculture/<sibling> \
+    --number 42 \
+    --body-file /tmp/follow-up.md
+```
+
+Or pipe the body in:
+
+```bash
+bash .claude/skills/communicate/scripts/post-comment.sh \
+    --repo agentculture/<sibling> \
+    --number 42 <<'EOF'
+PR #87 has shipped — closing the loop on this thread.
+EOF
+```
+
+Auto-signed by agtag from `culture.yaml`; do not hand-author the
+trailing nick.
+
+### Send a mesh channel message
+
+```bash
+bash .claude/skills/communicate/scripts/mesh-message.sh \
+    --channel "#general" \
+    --body "PR #42 — all review threads addressed. Ready for merge."
+```
+
+Body can also come from `--body-file PATH` or stdin. The script wraps
+`culture channel message <target> <text>` and forwards exit codes
+unchanged, so failures (no Culture server, agent not connected) surface
+verbatim. No signature is appended — the IRC nick is the speaker.
+
+### Fetch sibling-repo issues
+
+```bash
+bash .claude/skills/communicate/scripts/fetch-issues.sh 191 --repo agentculture/culture
+bash .claude/skills/communicate/scripts/fetch-issues.sh 191-197 --repo agentculture/culture
+bash .claude/skills/communicate/scripts/fetch-issues.sh 191 195 197
+```
+
+Output is one JSON object per issue (separated by header bars) with
+`number`, `title`, `state`, `labels`, `body`, and `comments`. Without
+`--repo`, `gh` resolves the repo from the current git remote. Failures
+on a single issue print `ERROR: Could not fetch issue #N` and continue
+with the next one.
+
+Steward is **not** a registered mesh agent today (see the cicd SKILL.md
+note). The script works once steward has been registered and started
+via `culture agent register` + `culture start spark-steward`; until
+then, calling it will fail with whatever error the Culture CLI returns,
+which is the right behavior — fix the registration, don't paper over it.
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/post-issue.sh` | Create a new issue on a target repo. Wraps `agtag issue post`; auto-signs from `culture.yaml`. |
+| `scripts/post-comment.sh` | Comment on an existing issue. Wraps `agtag issue reply`; auto-signs from `culture.yaml`. |
+| `scripts/fetch-issues.sh` | Fetch one or more issues (single / range / list) with body + comments. Wraps `agtag issue fetch`. |
+| `scripts/mesh-message.sh` | Send a message to a Culture mesh channel. Unsigned (IRC nick is the speaker). |
+| `scripts/templates/skill-update-brief.md` | The Markdown template consumed by `steward announce-skill-update` (the broadcast verb lives in steward-cli, not in this skill). Six fixed sections; placeholder syntax `{{NAME}}`. |
+
+More scripts can land here as the communication footprint grows —
+`mesh-ask.sh` for question-shaped pings via `culture channel ask`,
+agtag-mesh wrappers once `agtag message` ships in v0.2, etc. Add them
+when there's a second concrete need; do not pre-build for
+hypotheticals.
+
+## Red Flags
+
+**Never:**
+
+- Scaffold or write files into the *target* repo when the ask is an issue on
+  it. Handing off / onboarding is an **issue, not an edit** — a direct "set
+  them up" is still an instruction to file the brief. (In steward this is the
+  "Steward's lane" rule; the principle holds for any vendor of this skill.)
+- Post a brief that says "see steward's plan" without inlining the
+  content. Briefs must be self-contained.
+- Skip the issue signature. The script enforces it; do not introduce a
+  `--no-signature` flag.
+- Sign mesh messages with `- <nick> (Claude)`. The nick already says
+  who you are.
+- Use this skill for in-steward issues — use `gh issue create` or the
+  `cicd` skill instead.
+- Manually type `- <nick> (Claude)` at the end of an issue or comment
+  body — agtag appends it. Manual typing creates double-signatures.
+- Post the same ask twice across channels (issue + mesh). Pick one.
+  Tracked → issue. Ephemeral → mesh.
+- Use mesh mode for anything that needs acceptance criteria. If the
+  receiving agent has to decide "did I do this right?", you owe them
+  an issue.

--- a/.claude/skills/communicate/scripts/fetch-issues.sh
+++ b/.claude/skills/communicate/scripts/fetch-issues.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Fetch GitHub issues with full body and comments. Thin wrapper around
+# `agtag issue fetch` that keeps this skill's range/list expansion
+# (agtag is single-issue per call).
+#
+# Usage: fetch-issues.sh [RANGE|NUMBER...] [--repo OWNER/REPO]
+#   fetch-issues.sh 191-197                   # range
+#   fetch-issues.sh 191                       # single
+#   fetch-issues.sh 191 192 195               # list
+#   fetch-issues.sh --repo foo/bar 5          # explicit repo (otherwise gh resolves it from the git remote)
+
+set -euo pipefail
+
+REPO=""
+NUMBERS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      if [[ $# -lt 2 || -z "$2" ]]; then
+        echo "Error: --repo requires a value (OWNER/REPO)" >&2
+        echo "Usage: fetch-issues.sh [RANGE|NUMBER...] [--repo OWNER/REPO]" >&2
+        exit 1
+      fi
+      REPO="$2"
+      shift 2 ;;
+    *-*)  # range like 191-197
+      IFS='-' read -r start end <<< "$1"
+      for ((i=start; i<=end; i++)); do NUMBERS+=("$i"); done
+      shift ;;
+    *)  NUMBERS+=("$1"); shift ;;
+  esac
+done
+
+if [[ ${#NUMBERS[@]} -eq 0 ]]; then
+  echo "Usage: fetch-issues.sh [RANGE|NUMBER...] [--repo OWNER/REPO]" >&2
+  exit 1
+fi
+
+if ! command -v agtag >/dev/null 2>&1; then
+  echo "agtag not found on PATH. Install agtag (>=0.1) to use this skill." >&2
+  exit 2
+fi
+
+# agtag fetch resolves the repo from the local git remote when --repo
+# is omitted, matching the previous gh-based behavior.
+REPO_ARGS=()
+if [[ -n "$REPO" ]]; then
+  REPO_ARGS=(--repo "$REPO")
+fi
+
+for num in "${NUMBERS[@]}"; do
+  echo "========================================"
+  echo "ISSUE #${num}"
+  echo "========================================"
+  agtag issue fetch "${REPO_ARGS[@]}" --number "$num" --json \
+    || echo "ERROR: Could not fetch issue #${num}"
+  echo
+done

--- a/.claude/skills/communicate/scripts/mesh-message.sh
+++ b/.claude/skills/communicate/scripts/mesh-message.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Send a message to a Culture mesh channel.
+# Thin wrapper around `culture channel message <target> <text>`.
+# No signature is appended — the IRC nick is the speaker.
+#
+# Usage:
+#   mesh-message.sh --channel '#general' --body "Hello"
+#   mesh-message.sh --channel '#general' --body-file PATH
+#   mesh-message.sh --channel '#general'  < body-on-stdin
+
+usage() {
+    echo "Usage: mesh-message.sh --channel '#NAME' [--body TEXT | --body-file PATH | < stdin]" >&2
+    exit 2
+}
+
+if ! command -v culture >/dev/null 2>&1; then
+    echo "mesh-message: 'culture' CLI not found on PATH" >&2
+    echo "  Install agentculture/culture and ensure 'culture --version' works." >&2
+    exit 127
+fi
+
+CHANNEL=""
+BODY=""
+BODY_FILE=""
+
+require_value() {
+    if [[ $# -lt 2 ]]; then
+        echo "Missing value for $1" >&2
+        usage
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --channel)    require_value "$@"; CHANNEL="$2"; shift 2 ;;
+        --body)       require_value "$@"; BODY="$2"; shift 2 ;;
+        --body-file)  require_value "$@"; BODY_FILE="$2"; shift 2 ;;
+        -h|--help)    usage ;;
+        *) echo "Unknown flag: $1" >&2; usage ;;
+    esac
+done
+
+if [[ -z "$CHANNEL" ]]; then
+    echo "Missing --channel" >&2
+    usage
+fi
+
+if [[ -n "$BODY" && -n "$BODY_FILE" ]]; then
+    echo "Pass at most one of --body / --body-file (stdin is the third option)" >&2
+    usage
+fi
+
+if [[ -z "$BODY" ]]; then
+    if [[ -n "$BODY_FILE" ]]; then
+        BODY="$(cat "$BODY_FILE")"
+    elif [[ ! -t 0 ]]; then
+        BODY="$(cat)"
+    else
+        echo "No --body / --body-file given and stdin is a TTY — refusing to hang on cat." >&2
+        echo "Pass --body 'text', --body-file PATH, or pipe the body in." >&2
+        exit 2
+    fi
+fi
+
+if [[ -z "$BODY" ]]; then
+    echo "Empty message body" >&2
+    exit 2
+fi
+
+# Forward exit code from culture; if the agent isn't running or the
+# server is unreachable, the operator should see that error verbatim.
+exec culture channel message "$CHANNEL" "$BODY"

--- a/.claude/skills/communicate/scripts/post-comment.sh
+++ b/.claude/skills/communicate/scripts/post-comment.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Comment on an existing cross-repo issue. Thin wrapper around
+# `agtag issue reply` that mirrors `post-issue.sh`'s ergonomics.
+#
+# Signature: agtag resolves the signing nick from the local
+# `culture.yaml` (falling back to repo basename), so vendors do not
+# need to edit a literal here.
+#
+# Usage:
+#   post-comment.sh --repo OWNER/REPO --number N --body-file PATH
+#   post-comment.sh --repo OWNER/REPO --number N  < body-on-stdin
+
+usage() {
+    echo "Usage: post-comment.sh --repo OWNER/REPO --number N [--body-file PATH | < stdin]" >&2
+    exit 2
+}
+
+REPO=""
+NUMBER=""
+BODY_FILE=""
+
+require_value() {
+    if [[ $# -lt 2 ]]; then
+        echo "Missing value for $1" >&2
+        usage
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)       require_value "$@"; REPO="$2"; shift 2 ;;
+        --number)     require_value "$@"; NUMBER="$2"; shift 2 ;;
+        --body-file)  require_value "$@"; BODY_FILE="$2"; shift 2 ;;
+        -h|--help)    usage ;;
+        *) echo "Unknown flag: $1" >&2; usage ;;
+    esac
+done
+
+if [[ -z "$REPO" || -z "$NUMBER" ]]; then
+    usage
+fi
+
+if ! command -v agtag >/dev/null 2>&1; then
+    echo "agtag not found on PATH. Install agtag (>=0.1) to use this skill." >&2
+    exit 2
+fi
+
+if [[ -z "$BODY_FILE" ]]; then
+    if [[ -t 0 ]]; then
+        echo "No --body-file given and stdin is a TTY — refusing to hang on cat." >&2
+        echo "Pass --body-file PATH or pipe the body in." >&2
+        exit 2
+    fi
+    TMP_BODY=$(mktemp -t communicate-post-comment-body.XXXXXX)
+    trap 'rm -f "$TMP_BODY"' EXIT
+    cat > "$TMP_BODY"
+    BODY_FILE="$TMP_BODY"
+fi
+
+# Don't `exec` here: see post-issue.sh for the rationale (stdin-spooled
+# tempfile + EXIT trap; exec would skip the trap and leak the body).
+agtag issue reply --repo "$REPO" --number "$NUMBER" --body-file "$BODY_FILE"
+exit $?

--- a/.claude/skills/communicate/scripts/post-issue.sh
+++ b/.claude/skills/communicate/scripts/post-issue.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Post a cross-repo issue. Thin wrapper around `agtag issue post` that
+# preserves this skill's stable script path so existing callers
+# (e.g. steward-cli's `announce-skill-update`) keep working unchanged.
+#
+# Signature: agtag resolves the signing nick from the local
+# `culture.yaml` (falling back to repo basename), so vendors do not
+# need to edit a literal here.
+#
+# Usage:
+#   post-issue.sh --repo OWNER/REPO --title "Title" --body-file PATH
+#   post-issue.sh --repo OWNER/REPO --title "Title"  < body-on-stdin
+
+usage() {
+    echo "Usage: post-issue.sh --repo OWNER/REPO --title TITLE [--body-file PATH | < stdin]" >&2
+    exit 2
+}
+
+REPO=""
+TITLE=""
+BODY_FILE=""
+
+# Require a value to follow each flag (otherwise `--repo` with no argument
+# would crash on `$2` under `set -u` instead of printing usage).
+require_value() {
+    if [[ $# -lt 2 ]]; then
+        echo "Missing value for $1" >&2
+        usage
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo)       require_value "$@"; REPO="$2"; shift 2 ;;
+        --title)      require_value "$@"; TITLE="$2"; shift 2 ;;
+        --body-file)  require_value "$@"; BODY_FILE="$2"; shift 2 ;;
+        -h|--help)    usage ;;
+        *) echo "Unknown flag: $1" >&2; usage ;;
+    esac
+done
+
+if [[ -z "$REPO" || -z "$TITLE" ]]; then
+    usage
+fi
+
+if ! command -v agtag >/dev/null 2>&1; then
+    echo "agtag not found on PATH. Install agtag (>=0.1) to use this skill." >&2
+    exit 2
+fi
+
+# agtag has no stdin mode — spool body to a tempfile so both call shapes
+# (--body-file and stdin) reach agtag as --body-file.
+if [[ -z "$BODY_FILE" ]]; then
+    if [[ -t 0 ]]; then
+        echo "No --body-file given and stdin is a TTY — refusing to hang on cat." >&2
+        echo "Pass --body-file PATH or pipe the body in." >&2
+        exit 2
+    fi
+    TMP_BODY=$(mktemp -t communicate-post-issue-body.XXXXXX)
+    trap 'rm -f "$TMP_BODY"' EXIT
+    cat > "$TMP_BODY"
+    BODY_FILE="$TMP_BODY"
+fi
+
+# Don't `exec` here: when stdin spooled the body to a tempfile we set an
+# EXIT trap to delete it, and exec would replace the shell before the trap
+# could run, leaking the spooled body on disk.
+agtag issue post --repo "$REPO" --title "$TITLE" --body-file "$BODY_FILE"
+exit $?

--- a/.claude/skills/communicate/scripts/templates/skill-new-brief.md
+++ b/.claude/skills/communicate/scripts/templates/skill-new-brief.md
@@ -1,0 +1,85 @@
+<!-- markdownlint-disable MD041 -->
+<!-- This file is the NEW-SKILL template rendered by announce-skill-update -->
+<!-- when --new is passed. It posts as an issue body where GitHub supplies -->
+<!-- the title, so there's no H1 here on purpose. Placeholders use the -->
+<!-- `{{NAME}}` syntax; {{ORIGIN_BLOCK}} is empty unless --origin is given. -->
+
+## A new skill is available to vendor
+
+`{{SKILL}}` is a **new** skill in the AgentCulture mesh. Your repo does
+not have it yet — this brief tells you how to **add it fresh** (there is no
+older vendored copy to replace). If you maintain a `docs/skill-sources.md`
+provenance ledger, add a row for it; if not, just drop it into
+`.claude/skills/`.
+
+{{ORIGIN_BLOCK}}
+
+Relevant guildmaster CHANGELOG entries (where guildmaster picked the skill up):
+
+{{CHANGELOG_BLOCK}}
+
+## Cite locations (source of truth)
+
+- Local sibling checkout (preferred when available):
+  `../guildmaster/.claude/skills/{{SKILL}}/`
+- Remote, if the workspace doesn't include a local guildmaster checkout:
+  <https://github.com/agentculture/guildmaster/tree/main/.claude/skills/{{SKILL}}>
+
+guildmaster re-broadcasts this skill to the mesh, so its copy is the citation
+point even when the skill originates in another sibling (see origin note
+above, if present). The directory ships a `SKILL.md` and a `scripts/`
+directory per the AgentCulture skills-portability rule (each skill is
+self-contained; nothing reaches across skill boundaries at runtime).
+
+## What's in the upstream now
+
+`{{SKILL}}/scripts/` ({{UPSTREAM_SCRIPT_COUNT}} files):
+
+{{UPSTREAM_SCRIPT_LIST}}
+
+{{DELTA_BLOCK}}
+
+{{NOTE_BLOCK}}
+
+## What to do
+
+```bash
+# 0. Branch.
+git checkout -b skill/{{SKILL}}-add
+
+# 1. Add the skill fresh from upstream (no existing copy to remove).
+cp -R ../guildmaster/.claude/skills/{{SKILL}} .claude/skills/
+chmod +x .claude/skills/{{SKILL}}/scripts/*.sh 2>/dev/null || true
+
+# 2. If you keep docs/skill-sources.md, add a row pointing at
+#    ../guildmaster/.claude/skills/{{SKILL}}/ (record any local divergence).
+
+# 3. Bump version per project convention (CI version-check enforces in
+#    AgentCulture siblings); add a CHANGELOG entry.
+```
+
+## Acceptance criteria
+
+- `.claude/skills/{{SKILL}}/SKILL.md` is present with frontmatter
+  `name: {{SKILL}}`. **On the culture/devex backend, also add
+  `type: command`** — `core.skill_loader` requires all of `name`,
+  `description`, and `type:`, and a SKILL.md lacking `type:` is silently
+  skipped by `backends/claude_code/probe.py`.
+- `.claude/skills/{{SKILL}}/scripts/` contains the
+  {{UPSTREAM_SCRIPT_COUNT}} files listed above (and only those, unless your
+  repo intentionally adds extras — record divergence in the SKILL.md
+  frontmatter `description` per the AgentCulture vendoring policy).
+- All scripts are executable (`chmod +x`).
+- If you keep a `docs/skill-sources.md`, it lists `{{SKILL}}` with the
+  upstream `../guildmaster/.claude/skills/{{SKILL}}/`.
+- `CHANGELOG.md` has a new version entry describing the addition; the
+  version is bumped per project convention; CI's `version-check` job is green.
+
+## References
+
+- guildmaster CHANGELOG (release-by-release deltas):
+  <https://github.com/agentculture/guildmaster/blob/main/CHANGELOG.md>
+- `{{SKILL}}` SKILL.md:
+  <https://github.com/agentculture/guildmaster/blob/main/.claude/skills/{{SKILL}}/SKILL.md>
+- AgentCulture skills-portability rule (each vendor owns and may adapt its
+  copy): the `communicate` SKILL.md "Conventions in use" section.

--- a/.claude/skills/communicate/scripts/templates/skill-update-brief.md
+++ b/.claude/skills/communicate/scripts/templates/skill-update-brief.md
@@ -1,0 +1,101 @@
+<!-- markdownlint-disable MD041 -->
+<!-- This file is a template rendered by announce-skill-update.sh. -->
+<!-- It posts as an issue body where GitHub supplies the title, so -->
+<!-- there's no H1 here on purpose. Placeholders use `{{NAME}}` syntax. -->
+
+## What's stale
+
+Your repo's `.claude/skills/{{SKILL}}/` (or its older vendored
+name — see your `docs/skill-sources.md` if you keep a provenance
+ledger) is a vendored copy of the guildmaster skill that has since
+moved on. Relevant CHANGELOG entries from guildmaster:
+
+{{CHANGELOG_BLOCK}}
+
+## Cite locations (source of truth)
+
+- Local sibling checkout (preferred when available):
+  `../guildmaster/.claude/skills/{{SKILL}}/`
+- Remote, if the workspace doesn't include a local guildmaster checkout:
+  <https://github.com/agentculture/guildmaster/tree/main/.claude/skills/{{SKILL}}>
+
+The directory ships with a `SKILL.md` and a `scripts/` directory
+per the AgentCulture skills-portability rule (each skill is
+self-contained; nothing reaches across skill boundaries at
+runtime).
+
+## What's in the upstream now
+
+`{{SKILL}}/scripts/` ({{UPSTREAM_SCRIPT_COUNT}} files):
+
+{{UPSTREAM_SCRIPT_LIST}}
+
+{{DELTA_BLOCK}}
+
+{{NOTE_BLOCK}}
+
+## What to do
+
+```bash
+# 0. Branch.
+git checkout -b skill/{{SKILL}}-resync
+
+# 1. Replace your vendored copy with the current upstream.
+#    If your old vendored name differs (e.g. pr-review → cicd),
+#    `git rm` the old dir first.
+git rm -r .claude/skills/<old-name-if-different>   # skip if name is already {{SKILL}}
+cp -R ../guildmaster/.claude/skills/{{SKILL}} .claude/skills/
+chmod +x .claude/skills/{{SKILL}}/scripts/*.sh 2>/dev/null || true
+
+# 2. Adapt identifiers per the existing "identifier-only adapted"
+#    pattern in your docs/skill-sources.md (if you keep one):
+#    - SKILL.md prose framing: replace "guildmaster" with your repo
+#      name where it identifies the consumer (NOT where it cites
+#      guildmaster as the upstream).
+#    - For any script that hard-codes a signature literal, change it
+#      to `- <your-repo> (Claude)`. (The communicate skill no longer
+#      hard-codes one — agtag resolves the nick from your local
+#      `culture.yaml`. If your repo is missing one, add it or pass
+#      `--as <your-repo>` at the call site.)
+
+# 3. Update docs/skill-sources.md (if present) to point at the
+#    new path; drop any stale row for the old name.
+
+# 4. Sweep for stale references:
+grep -rn '<old-name-if-different>' .claude docs CLAUDE.md README.md 2>/dev/null
+#    Replace any survivors with `{{SKILL}}`.
+
+# 5. Bump version per project convention (CI version-check
+#    enforces in AgentCulture siblings); add CHANGELOG entry.
+```
+
+## Acceptance criteria
+
+- `.claude/skills/{{SKILL}}/SKILL.md` is present with frontmatter
+  `name: {{SKILL}}`.
+- `.claude/skills/{{SKILL}}/scripts/` contains the
+  {{UPSTREAM_SCRIPT_COUNT}} files listed above (and only those
+  files, unless your repo intentionally adds extras — record
+  divergence in the SKILL.md frontmatter `description` per the
+  AgentCulture vendoring policy).
+- All scripts are executable (`chmod +x`).
+- If the skill hard-codes a signature literal anywhere, your
+  vendored copy uses your repo's signature, not `- guildmaster (Claude)`.
+- If you keep a `docs/skill-sources.md`, it lists `{{SKILL}}` with
+  the upstream `../guildmaster/.claude/skills/{{SKILL}}/`; no row
+  remains for the old vendored name.
+- `grep -rn '<old-name-if-different>' .claude docs CLAUDE.md README.md`
+  returns zero hits, or only historical mentions in CHANGELOG.
+- `CHANGELOG.md` has a new version entry describing the resync;
+  the version is bumped per project convention; CI's
+  `version-check` job is green.
+
+## References
+
+- guildmaster CHANGELOG (release-by-release deltas):
+  <https://github.com/agentculture/guildmaster/blob/main/CHANGELOG.md>
+- `{{SKILL}}` SKILL.md:
+  <https://github.com/agentculture/guildmaster/blob/main/.claude/skills/{{SKILL}}/SKILL.md>
+- AgentCulture skills-portability rule (why each vendor adapts
+  signature literals locally): the `communicate` SKILL.md
+  "Per-channel signature rules" + "Conventions in use" sections.

--- a/.claude/skills/doc-test-alignment/SKILL.md
+++ b/.claude/skills/doc-test-alignment/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: doc-test-alignment
+type: command
+description: >
+  Verify that committed docs (README.md, CLAUDE.md, SKILL.md descriptions) still
+  describe what the code and tests actually do. Use at the end of a plan, before
+  PR creation, or when the user says "check doc-test alignment", "verify docs",
+  or "do the docs still match the code". STUB — `scripts/check.sh` exits with a
+  not-yet-implemented error today; the contract for what it will do lives in
+  this file.
+---
+
+# doc-test-alignment (stub)
+
+This skill is a stub. The real workflow is intentionally not yet implemented —
+the file exists so that `steward verify` can find it and so contributors who
+land here know it is on the roadmap, not forgotten.
+
+## How to run
+
+`scripts/check.sh` is the entry point. Today it prints a not-yet-implemented
+notice and exits non-zero. When the workflow lands, the script will gate
+PR-readiness on the alignment contract below; until then, treat any green
+exit code from this script as a bug.
+
+## What it will check
+
+The skill is the contract for four narrow alignments. README.md command
+examples must still execute against the current checkout and produce output
+that matches the surrounding prose. The "build/test/publish" command lines in
+CLAUDE.md must do the same. For each `.claude/skills/<name>/`, the SKILL.md
+`description` frontmatter must agree with what the scripts under
+`scripts/` actually do — surfacing disagreements (e.g. SKILL.md claims the
+skill bumps versions but `scripts/` has no bump script). And for each test,
+the test name should still describe the assertions the test makes — flagging
+drift where the name advertises a feature the assertions no longer touch.
+
+## Why it ships as a stub
+
+Each of those four checks is independently non-trivial. Shipping a partial
+implementation would either silently pass when it shouldn't, or false-positive
+on intentional doc-vs-code differences. The right path is to land the checks
+one at a time, with their own tests, behind a
+`steward verify --check doc-test-alignment` flag. The parent verbs (`verify`,
+`doctor`) are named in the "Roadmap" section of `CLAUDE.md`; the broader
+sibling-pattern contract lives in `docs/sibling-pattern.md`.
+
+## What this stub guarantees today
+
+- The skill directory exists, so `steward verify`'s skills-convention check
+  finds the standard layout (SKILL.md + `scripts/` with an entry-point).
+- `scripts/check.sh` is the entry-point script, satisfying the steward skills
+  convention requirement that every skill ships an executable script.
+- This `SKILL.md` is the contract for what the skill will do — when the
+  implementation lands, it must satisfy this description or the description
+  must move first.

--- a/.claude/skills/doc-test-alignment/scripts/check.sh
+++ b/.claude/skills/doc-test-alignment/scripts/check.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# doc-test-alignment skill — entry point.
+#
+# STUB: the real workflow is not implemented yet. This script exists so the
+# steward skills convention is satisfied (every skill ships an executable
+# entry-point script); when the real implementation lands here, it must
+# satisfy the contract documented in ../SKILL.md.
+#
+# Exits 2 (EXIT_USER_ERROR-ish for "you asked for something that isn't
+# wired up yet") so callers can tell the difference between "checks passed"
+# (would be 0) and "stub".
+
+set -euo pipefail
+
+cat >&2 <<'EOF'
+doc-test-alignment: not yet implemented.
+
+This skill is a stub; the contract for what `check.sh` will assert lives in
+.claude/skills/doc-test-alignment/SKILL.md. Until the implementation lands,
+treat any green exit code from this script as a bug.
+
+Roadmap: see CLAUDE.md ("Roadmap (CLI surface)") and docs/sibling-pattern.md.
+EOF
+exit 2

--- a/.claude/skills/outsource/SKILL.md
+++ b/.claude/skills/outsource/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: outsource
+type: command
+description: >
+  Hand a scoped repo task to convertible — a *different* engine/model than you
+  (e.g. a local vLLM Qwen) — and fold its answer back. The point isn't a stronger
+  model; it's a different mind, and diversity helps: `outsource review` gets an
+  independent second opinion on a diff, `outsource explore` gets a fresh read of
+  an area, `outsource write` delegates a small implementation. Use when the user
+  says "outsource this", "get a second opinion", "have convertible review/explore/
+  write", "ask the other model", or when you want a diverse perspective rather
+  than just doing it yourself. Read-only verbs (explore/review) run isolated in a
+  throwaway git worktree and cannot touch the working tree.
+---
+
+# outsource — use convertible as a different mind
+
+`outsource` drives the **`convertible`** CLI so a Claude agent can hand a scoped
+task to a *different* engine (default: a local vLLM `Qwen3.6-27B` on
+`:8001`). Convertible's model is **not** assumed to be stronger than you — its
+value is **diversity**. A second, independent mind catches things the author's
+mind glides past, which is why **review** is the headline verb.
+
+This skill is the operator: a portable wrapper that resolves the CLI and turns
+each verb into a `convertible drive`, then prints the drive's result summary.
+
+## How to run
+
+The entry point is `scripts/outsource.sh`. Invoke it from the repo you want
+convertible to work on:
+
+```bash
+bash .claude/skills/outsource/scripts/outsource.sh <verb> "<text>" [options]
+```
+
+It resolves the CLI portably — an installed `convertible` on `PATH` (the normal
+case), falling back to `uv run convertible` when inside the convertible checkout,
+else an install hint.
+
+### Verbs
+
+| Verb | What it does | Side effects |
+|------|--------------|--------------|
+| `explore "<question or area>"` | Read-only investigation of the repo; the model reads and reports findings. | **None** — runs in a throwaway worktree at HEAD. |
+| `review "<what to focus on>" [--base main]` | A diverse second opinion on the **committed** diff (`<base>...HEAD`). | **None** — throwaway worktree; reviews committed changes only. |
+| `write "<task>" [--pr]` | Implement a change. Commits to a drive branch by default; `--pr` pushes + opens a PR. | In-place: a `convertible/<id>` drive branch (or a PR). |
+
+### Options
+
+| Option | Meaning |
+|--------|---------|
+| `--repo PATH` | Target repo (default: `.`). |
+| `--base BRANCH` | Base for the `review` diff (default: `main`). |
+| `--engine NAME` | Engine wheel (default: `$CONVERTIBLE_ENGINE` or `vllm-openai`). |
+| `--model NAME` | Model (default: `$CONVERTIBLE_MODEL` or `mmangkad/Qwen3.6-27B-NVFP4`). |
+| `--base-url URL` | OpenAI base URL (default: `$CONVERTIBLE_BASE_URL` or `http://localhost:8001/v1`). |
+| `--max-steps N` | Loop step budget (default: 20). |
+| `--allow-dirty` | (`write`) allow running on a dirty tree. |
+| `--pr` | (`write`) push + open a PR instead of a local drive branch. |
+
+The result printed to stdout is the drive's `TaskResult.summary` (plus
+`changed_files` / drive branch for `write`), parsed from `convertible drive
+--json`. Per-step progress streams to stderr while it runs.
+
+## When to reach for which verb
+
+- **review** — the standing use. You wrote (or an agent wrote) a change and you
+  want a candid, independent pass over the *committed* diff before you trust it.
+  Treat the output as a second opinion to weigh, not a verdict.
+- **explore** — you want a fresh, unbiased read of an unfamiliar area ("how does
+  X work here?") without anchoring on your own assumptions.
+- **write** — a small, well-scoped implementation you're happy to delegate. The
+  result lands on a drive branch you can inspect, merge, or discard.
+
+## Hard rules (do not violate)
+
+- **explore and review are read-only.** They run in a throwaway `git worktree`
+  at HEAD, so a stray write can't reach your working tree or branch; the prompts
+  also tell the model not to modify anything. Don't route a change-making task
+  through them — use `write`.
+- **`write` refuses a dirty tree** unless you pass `--allow-dirty`. This guards
+  the dirty-tree hazard: `convertible drive --no-pr` commits *uncommitted* edits
+  onto the drive branch and leaves you there. Commit or stash first.
+- **Outsourced output is a second opinion, not authority.** The engine may be a
+  smaller/different model; weigh its findings, verify its claims, and own the
+  decision yourself.
+
+## Honest limits
+
+- Read-only is enforced by **worktree isolation + prompt constraint**, not a
+  sandbox — the loop always exposes `write_file`/`run_command`, so the model can
+  still run arbitrary *read-only* commands.
+- `review` covers **committed** changes only (`<base>...HEAD`). To review
+  uncommitted work, commit it first.
+- The default engine is whatever single model is running locally; a multi-model
+  fleet (different model per verb) is separate infrastructure.
+
+## Provenance
+
+This is a **first-party convertible** skill — `agentculture/convertible` is its
+origin. guildmaster **re-broadcasts** it to the mesh (the same inbound pattern as
+the devague-origin workflow skills), tracking it in `docs/skill-sources.md`. The
+`cite, don't import` policy holds: downstream repos copy it, they don't symlink
+or depend on it.

--- a/.claude/skills/outsource/prompts/explore.md
+++ b/.claude/skills/outsource/prompts/explore.md
@@ -1,0 +1,20 @@
+You are a second, independent mind brought in for a fresh read of this repository.
+You are NOT the original author — your value is a different perspective, not authority.
+
+Investigate the following and report what you find:
+
+$ARGUMENTS
+
+Rules:
+- This is READ-ONLY. Use read_file, list_dir, and read-only run_command only
+  (e.g. `git log`, `git grep`, `ls`, `rg`). Do NOT create, modify, or delete any
+  file, and do NOT run any command that changes state.
+- Be concrete: cite file paths and line numbers; quote the key code you rely on.
+- Surface what's surprising, risky, or unclear — not just a tidy summary.
+- You have a limited step budget. Read efficiently and call finish with your
+  report well before you run out — a focused finding beats endless reading.
+
+When you are done, call finish with a structured findings report:
+1. What it is / how it works (with file:line references).
+2. Notable details, edge cases, or surprises.
+3. Open questions or risks worth a closer look.

--- a/.claude/skills/outsource/prompts/review.md
+++ b/.claude/skills/outsource/prompts/review.md
@@ -1,0 +1,27 @@
+You are an independent reviewer — a different mind from whoever wrote this change.
+Your job is a candid second opinion, not a rubber stamp.
+
+Focus the review on:
+
+$ARGUMENTS
+
+The change under review is the committed diff on this branch versus its base
+(`$BASE`). Start by running, read-only:
+
+    git diff $BASE...HEAD --stat
+    git diff $BASE...HEAD
+
+then read the touched files for the context you need.
+
+Rules:
+- READ-ONLY. Do NOT modify, create, or delete any file. Only read and run
+  read-only commands.
+- Be terse and prioritized — lead with what actually matters. Don't pad.
+- Call out real problems; if it's genuinely fine, say so and say why.
+- You have a limited step budget. Read the diff efficiently and call finish with
+  your review well before you run out of steps.
+
+When you are done, call finish with a structured review:
+1. Correctness risks / likely bugs (with file:line).
+2. Design, clarity, or maintainability concerns.
+3. Concrete, actionable suggestions (ranked; most important first).

--- a/.claude/skills/outsource/prompts/write.md
+++ b/.claude/skills/outsource/prompts/write.md
@@ -1,0 +1,13 @@
+Implement the following task in this repository:
+
+$ARGUMENTS
+
+Rules:
+- Make the SMALLEST change that correctly satisfies the task.
+- Follow the repository's existing patterns, style, and conventions — read the
+  neighbouring files first so your change reads like the surrounding code.
+- You may read, create, modify files, and run commands as needed.
+- Don't widen the scope: do exactly what was asked, nothing more.
+
+When you are done, call finish with a short summary of exactly what you changed
+and why.

--- a/.claude/skills/outsource/scripts/outsource.sh
+++ b/.claude/skills/outsource/scripts/outsource.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+#
+# outsource — hand a scoped repo task to convertible (a different engine/mind).
+#
+# Convertible's engine is not necessarily stronger than the calling agent; it is
+# a *different* mind, and diversity helps — which is why `review` is the headline
+# verb. Three verbs drive `convertible drive` and print the result:
+#
+#   outsource explore "<question or area>"   read-only investigation -> findings
+#   outsource review  "<what to focus on>"   diverse second-opinion on the diff
+#   outsource write   "<task>" [--pr]        implement a change
+#
+# explore/review run in a throwaway `git worktree` at HEAD, so they can never
+# touch your working tree or branch (any stray write is discarded). write runs
+# in-place and lands a drive branch (or a PR with --pr).
+#
+set -euo pipefail
+
+SKILL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROMPTS_DIR="$SKILL_DIR/prompts"
+
+# ── resolve the convertible CLI (installed, then local-dev fallback) ─────────
+CONVERTIBLE=()
+resolve_convertible() {
+    if command -v convertible >/dev/null 2>&1; then
+        CONVERTIBLE=(convertible)        # installed tool — the normal case
+        return 0
+    fi
+    # Local-dev fallback: inside the convertible checkout, run via uv.
+    local dir="$PWD"
+    while [[ -n "$dir" ]] && [[ "$dir" != "/" ]]; do
+        if [[ -f "$dir/pyproject.toml" ]] \
+            && grep -q '^name = "convertible-cli"' "$dir/pyproject.toml" 2>/dev/null; then
+            if command -v uv >/dev/null 2>&1; then
+                CONVERTIBLE=(uv run convertible)
+                return 0
+            fi
+            break
+        fi
+        dir=$(dirname "$dir")
+    done
+    cat >&2 <<'EOF'
+error: convertible CLI not found.
+hint: install it with `uv tool install convertible-cli` (or `pipx install convertible-cli`),
+      or run from inside the convertible checkout with `uv` available.
+      https://github.com/agentculture/convertible
+EOF
+    return 1
+}
+
+usage() {
+    cat <<'EOF'
+outsource — hand a scoped repo task to convertible (a different engine/mind).
+
+Usage:
+  outsource explore "<question or area>"     Read-only investigation -> findings (no side effects)
+  outsource review  "<what to focus on>"     Diverse second-opinion on the committed diff (no side effects)
+  outsource write   "<task>" [--pr]          Implement a change (drive branch, or PR with --pr)
+
+Options:
+  --repo PATH        Target repo (default: .)
+  --base BRANCH      Base for `review` diff (default: main)
+  --engine NAME      Engine wheel (default: $CONVERTIBLE_ENGINE or vllm-openai)
+  --model NAME       Model (default: $CONVERTIBLE_MODEL or mmangkad/Qwen3.6-27B-NVFP4)
+  --base-url URL     OpenAI base URL (default: $CONVERTIBLE_BASE_URL or http://localhost:8001/v1)
+  --max-steps N      Loop step budget (default: 20)
+  --timeout N        Per-request timeout, seconds (default: $CONVERTIBLE_TIMEOUT or 300)
+  --allow-dirty      (write) allow running on a dirty tree
+  --pr               (write) push + open a PR instead of a local drive branch
+
+explore/review run in a throwaway git worktree at HEAD — they cannot touch your
+working tree or branch. review compares <base>...HEAD (committed changes only).
+EOF
+}
+
+# ── parse the verb ──────────────────────────────────────────────────────────
+VERB="${1:-}"
+case "$VERB" in
+    explore | review | write) shift ;;
+    -h | --help) usage; exit 0 ;;
+    "") usage >&2; exit 2 ;;
+    *)
+        echo "error: unknown verb '$VERB' (expected explore|review|write)" >&2
+        echo "hint: run 'outsource --help'" >&2
+        exit 2
+        ;;
+esac
+
+# Required external tools — fail fast with a clear message, not an opaque
+# mid-run error, if the environment is missing one.
+require_tools() {
+    local missing=() t
+    for t in python3 git grep mktemp; do
+        command -v "$t" >/dev/null 2>&1 || missing+=("$t")
+    done
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "error: missing required tool(s): ${missing[*]}" >&2
+        echo "hint: outsource needs python3, git, grep, and mktemp on PATH." >&2
+        exit 2
+    fi
+}
+
+# Guard a value-taking flag: a trailing flag with no value would otherwise
+# dereference an unset $2 and abort under `set -u`.
+need_value() {  # $1 = remaining arg count ($#), $2 = flag name
+    [[ "$1" -ge 2 ]] || {
+        echo "error: $2 requires a value" >&2
+        echo "hint: run 'outsource --help'" >&2
+        exit 2
+    }
+}
+
+require_tools
+
+# ── defaults + flag parsing ─────────────────────────────────────────────────
+REPO="."
+BASE="main"
+ENGINE="${CONVERTIBLE_ENGINE:-vllm-openai}"
+MODEL="${CONVERTIBLE_MODEL:-mmangkad/Qwen3.6-27B-NVFP4}"
+BASE_URL="${CONVERTIBLE_BASE_URL:-http://localhost:8001/v1}"
+MAX_STEPS=20
+TIMEOUT="${CONVERTIBLE_TIMEOUT:-300}"
+ALLOW_DIRTY=0
+OPEN_PR=0
+ARG=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --repo) need_value "$#" "$1"; REPO="$2"; shift 2 ;;
+        --base) need_value "$#" "$1"; BASE="$2"; shift 2 ;;
+        --engine) need_value "$#" "$1"; ENGINE="$2"; shift 2 ;;
+        --model) need_value "$#" "$1"; MODEL="$2"; shift 2 ;;
+        --base-url) need_value "$#" "$1"; BASE_URL="$2"; shift 2 ;;
+        --max-steps) need_value "$#" "$1"; MAX_STEPS="$2"; shift 2 ;;
+        --timeout) need_value "$#" "$1"; TIMEOUT="$2"; shift 2 ;;
+        --allow-dirty) ALLOW_DIRTY=1; shift ;;
+        --pr) OPEN_PR=1; shift ;;
+        -h | --help) usage; exit 0 ;;
+        --) shift; while [[ $# -gt 0 ]]; do ARG="${ARG:+$ARG }$1"; shift; done ;;
+        -*) echo "error: unknown option '$1'" >&2; echo "hint: run 'outsource --help'" >&2; exit 2 ;;
+        *) ARG="${ARG:+$ARG }$1"; shift ;;
+    esac
+done
+
+[[ -n "$ARG" ]] || { echo "error: $VERB needs a description argument" >&2; usage >&2; exit 2; }
+[[ -d "$REPO" ]] || { echo "error: --repo is not a directory: $REPO" >&2; exit 2; }
+REPO="$(cd "$REPO" && pwd)"
+
+resolve_convertible || exit 2
+
+# Per-request timeout is config (no drive flag); EngineConfig reads it from env.
+# A local model can be slow on a growing context, so default generously.
+export CONVERTIBLE_TIMEOUT="$TIMEOUT"
+COMMON_FLAGS=(--engine "$ENGINE" --model "$MODEL" --base-url "$BASE_URL" --max-steps "$MAX_STEPS" --json)
+
+# ── render an instruction from a prompt template ────────────────────────────
+render_prompt() {
+    local file="$PROMPTS_DIR/$1.md"
+    [[ -f "$file" ]] || { echo "error: missing prompt template: $file" >&2; exit 2; }
+    ARG="$ARG" BASE="$BASE" python3 - "$file" <<'PY'
+import os, sys
+tpl = open(sys.argv[1], encoding="utf-8").read()
+sys.stdout.write(tpl.replace("$ARGUMENTS", os.environ["ARG"]).replace("$BASE", os.environ["BASE"]))
+PY
+}
+
+# ── print the TaskResult that convertible emitted as JSON on stdout ─────────
+# Reads JSON on stdin; prints a human/agent-readable digest; exits non-zero if
+# the drive failed.
+print_result() {
+    # NOTE: must be `python3 -c`, not `python3 - <<HEREDOC`: a heredoc becomes
+    # python's stdin (the script source), which would shadow the piped JSON and
+    # leave sys.stdin.read() empty. The script body uses no single quotes.
+    python3 -c '
+import sys, json
+raw = sys.stdin.read().strip()
+if not raw:
+    sys.stderr.write("error: convertible produced no result on stdout (see diagnostics above)\n")
+    sys.exit(2)
+try:
+    d = json.loads(raw)
+except Exception:
+    sys.stderr.write("error: could not parse convertible --json output:\n")
+    sys.stderr.write(raw[:2000] + "\n")
+    sys.exit(2)
+print("status:", d.get("status"))
+print()
+print((d.get("summary") or "").rstrip())
+cf = d.get("changed_files") or []
+if cf:
+    print("\nchanged files:", ", ".join(cf))
+if d.get("branch"):
+    print("drive branch:", d["branch"])
+if d.get("artifacts_path"):
+    print("artifact:", d["artifacts_path"])
+sys.exit(0 if d.get("status") == "ok" else 1)
+'
+}
+
+# ── read-only verbs: isolate the drive in a throwaway worktree at HEAD ──────
+# Worktree state is module-global, not a function local: the EXIT trap fires
+# *after* run_readonly returns, so under `set -u` a local would be unbound.
+_WT=""
+_DRIVE_BRANCH=""
+
+_cleanup_worktree() {
+    [[ -n "$_WT" ]] || return 0
+    git -C "$REPO" worktree remove --force "$_WT" >/dev/null 2>&1 || true
+    rm -rf "$_WT" >/dev/null 2>&1 || true
+    # Only ever delete the ephemeral drive branch convertible names
+    # (convertible/<task_id>) — never an unrelated local branch, even if the
+    # JSON `branch` value were unexpected.
+    if [[ "$_DRIVE_BRANCH" == convertible/* ]]; then
+        git -C "$REPO" branch -D "$_DRIVE_BRANCH" >/dev/null 2>&1 || true
+    fi
+}
+
+run_readonly() {
+    local instruction="$1"
+    git -C "$REPO" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+        || { echo "error: --repo is not a git repository: $REPO" >&2; exit 2; }
+
+    _WT="$(mktemp -d)"
+    trap _cleanup_worktree EXIT
+    git -C "$REPO" worktree add -q --detach "$_WT" HEAD
+
+    local out
+    out="$("${CONVERTIBLE[@]}" drive "$instruction" --repo "$_WT" --no-pr "${COMMON_FLAGS[@]}")" || true
+    _DRIVE_BRANCH="$(printf '%s' "$out" | python3 -c 'import sys, json
+try:
+    print(json.load(sys.stdin).get("branch") or "")
+except Exception:
+    print("")' 2>/dev/null || true)"
+    printf '%s' "$out" | print_result
+}
+
+# ── write verb: in-place drive (drive branch, or PR with --pr) ──────────────
+run_write() {
+    local instruction="$1"
+    if [[ "$ALLOW_DIRTY" -eq 0 ]] \
+        && [[ -n "$(git -C "$REPO" status --porcelain 2>/dev/null)" ]]; then
+        echo "error: working tree is dirty — commit/stash first, or pass --allow-dirty" >&2
+        echo "hint: 'convertible drive --no-pr' commits uncommitted edits onto the drive branch" >&2
+        exit 2
+    fi
+    local out
+    if [[ "$OPEN_PR" -eq 1 ]]; then
+        out="$("${CONVERTIBLE[@]}" drive "$instruction" --repo "$REPO" "${COMMON_FLAGS[@]}")"
+    else
+        out="$("${CONVERTIBLE[@]}" drive "$instruction" --repo "$REPO" --no-pr "${COMMON_FLAGS[@]}")"
+    fi
+    printf '%s' "$out" | print_result
+}
+
+case "$VERB" in
+    explore) run_readonly "$(render_prompt explore)" ;;
+    review) run_readonly "$(render_prompt review)" ;;
+    write) run_write "$(render_prompt write)" ;;
+esac

--- a/.claude/skills/pypi-maintainer/SKILL.md
+++ b/.claude/skills/pypi-maintainer/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: pypi-maintainer
+type: command
+description: >
+  Switch a PyPI package install between the production index, TestPyPI
+  pre-release builds, and a local editable checkout. Use when an agent
+  maintains a package and needs to verify a TestPyPI dev build before
+  promoting to production, or when the user says "install from
+  test-pypi", "switch to local", "change package source", or
+  "install from pypi".
+---
+
+# PyPI Maintainer
+
+Switch the install source for a package the agent maintains. Three sources
+are supported: production PyPI, TestPyPI (pre-release / dev builds), and a
+local editable checkout. The same script works for any package an
+AgentCulture sibling publishes — pass the package name as the first
+argument.
+
+## When to use
+
+- Verifying a PR's TestPyPI dev build before merging.
+- Reproducing a user-reported bug against the published version.
+- Hot-patching against a local checkout while a fix is in flight.
+- Restoring the production install after local-mode debugging.
+
+## Usage
+
+```bash
+# Production PyPI
+bash .claude/skills/pypi-maintainer/scripts/switch-source.sh <package> pypi
+
+# TestPyPI (pre-release dev builds)
+bash .claude/skills/pypi-maintainer/scripts/switch-source.sh <package> test-pypi
+
+# TestPyPI, pinned to a specific dev version
+bash .claude/skills/pypi-maintainer/scripts/switch-source.sh <package> test-pypi --version 0.4.0.dev42
+
+# Local editable checkout (defaults to current directory)
+bash .claude/skills/pypi-maintainer/scripts/switch-source.sh <package> local
+
+# Local editable from an explicit path
+bash .claude/skills/pypi-maintainer/scripts/switch-source.sh <package> local --path ../<package>
+```
+
+## Prerequisites
+
+The script requires the following tools on `PATH`:
+
+- `bash`
+- `uv` — the script delegates to `uv tool install` and `uv tool list`
+  (or `uv pip install` for `local`).
+
+## Why TestPyPI needs special flags
+
+When a package is published to **both** PyPI and TestPyPI, `uv tool install`
+finds the production version on PyPI first and never looks at TestPyPI.
+The script passes `--index-strategy unsafe-best-match` so uv compares the
+two index sets and picks the highest version, plus `--prerelease=allow`
+because TestPyPI builds carry dev suffixes (e.g. `0.4.0.dev42`).
+
+## After running
+
+The script prints the resolved version once install completes — cross-check
+that against the expected version (PR run number, local `pyproject.toml`)
+before continuing.
+
+## Arguments
+
+| Position / flag | Meaning |
+|-----------------|---------|
+| `<package>` (required) | The PyPI distribution name, e.g. `steward-cli`, `culture`, `daria-cli`. |
+| `<source>` (required)  | One of `pypi`, `test-pypi`, `local`. |
+| `--version VERSION`    | Pin to a specific version (TestPyPI builds typically need this). |
+| `--path PATH`          | Local-source-only: path to the editable checkout (default: cwd). |

--- a/.claude/skills/pypi-maintainer/scripts/switch-source.sh
+++ b/.claude/skills/pypi-maintainer/scripts/switch-source.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# switch-source.sh — Switch a PyPI package install between pypi / test-pypi / local.
+#
+# Usage:
+#   switch-source.sh <package> pypi
+#   switch-source.sh <package> test-pypi [--version VERSION]
+#   switch-source.sh <package> local [--path PATH]
+#
+# Generalised from the original culture-specific change-package skill so any
+# AgentCulture sibling that publishes a PyPI package can vendor and use it.
+
+set -euo pipefail
+
+PACKAGE=""
+SOURCE=""
+VERSION=""
+LOCAL_PATH=""
+
+usage() {
+  cat <<EOF >&2
+Usage: switch-source.sh <package> <pypi|test-pypi|local> [options]
+
+Options:
+  --version VERSION   Pin to a specific version (most useful for test-pypi
+                      dev builds, e.g. --version 0.4.0.dev42).
+  --path PATH         Local source only: path to editable checkout
+                      (default: current directory).
+  -h, --help          Show this help.
+EOF
+}
+
+# --- Parse args ---
+require_value() {
+  local flag="$1" remaining="$2"
+  if [[ "$remaining" -lt 2 ]]; then
+    echo "Error: $flag requires a value" >&2
+    usage
+    exit 1
+  fi
+}
+
+POSITIONAL=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version) require_value "$1" "$#"; VERSION="$2"; shift 2 ;;
+    --path)    require_value "$1" "$#"; LOCAL_PATH="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    --*)       echo "Unknown option: $1" >&2; usage; exit 1 ;;
+    *)         POSITIONAL+=("$1"); shift ;;
+  esac
+done
+
+if [[ ${#POSITIONAL[@]} -lt 2 ]]; then
+  usage
+  exit 1
+fi
+
+PACKAGE="${POSITIONAL[0]}"
+SOURCE="${POSITIONAL[1]}"
+
+# --- Resolve install spec for pinned versions ---
+SPEC="$PACKAGE"
+if [[ -n "$VERSION" ]]; then
+  SPEC="${PACKAGE}==${VERSION}"
+fi
+
+case "$SOURCE" in
+  pypi)
+    echo "Installing $SPEC from production PyPI..."
+    uv tool install "$SPEC" --force
+    ;;
+  test-pypi)
+    echo "Installing $SPEC from TestPyPI..."
+    uv tool install "$SPEC" \
+      --index-url https://test.pypi.org/simple/ \
+      --extra-index-url https://pypi.org/simple/ \
+      --index-strategy unsafe-best-match \
+      --prerelease=allow \
+      --force
+    ;;
+  local)
+    if [[ -z "$LOCAL_PATH" ]]; then
+      LOCAL_PATH="$(pwd)"
+    fi
+    if [[ ! -f "$LOCAL_PATH/pyproject.toml" ]]; then
+      echo "Error: $LOCAL_PATH does not contain a pyproject.toml" >&2
+      exit 1
+    fi
+    echo "Installing $PACKAGE in editable mode from $LOCAL_PATH..."
+    uv tool install --from "$LOCAL_PATH" --editable "$PACKAGE" --force
+    ;;
+  *)
+    echo "Unknown source: $SOURCE (expected pypi, test-pypi, or local)" >&2
+    usage
+    exit 1
+    ;;
+esac
+
+# --- Report what is now active ---
+echo
+echo "Installed tools matching '$PACKAGE':"
+uv tool list 2>/dev/null | awk -v pkg="$PACKAGE" 'tolower($1) == tolower(pkg) {print "  " $0}'

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: run-tests
+type: command
+description: Run pytest with parallel execution and coverage. Use when running tests, verifying changes, or the user says "run tests", "test", or "pytest".
+---
+
+# Run Tests
+
+Run the project's pytest suite with optional parallelism (pytest-xdist) and coverage.
+Coverage targets are read from `pyproject.toml`'s `[tool.coverage.run]` section,
+so the same script works in any sibling repo without modification.
+
+## Usage
+
+```bash
+# Default: parallel + verbose (recommended)
+bash .claude/skills/run-tests/scripts/test.sh -p
+
+# Quick check: parallel + quiet
+bash .claude/skills/run-tests/scripts/test.sh -p -q
+
+# Full CI mode: parallel + coverage + xml report
+bash .claude/skills/run-tests/scripts/test.sh --ci
+
+# Specific test file
+bash .claude/skills/run-tests/scripts/test.sh -p tests/test_socket_server.py
+
+# Without parallelism (for debugging test ordering issues)
+bash .claude/skills/run-tests/scripts/test.sh tests/test_rooms.py
+
+# With coverage
+bash .claude/skills/run-tests/scripts/test.sh -p -c
+```
+
+## Options
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--parallel` | `-p` | Run with `-n auto` (pytest-xdist, uses all CPU cores) |
+| `--coverage` | `-c` | Enable coverage reporting to terminal |
+| `--ci` | | Full CI mode: parallel + coverage + XML report + verbose |
+| `--quick` | `-q` | Quiet output (no verbose, no coverage) |
+
+Extra arguments are passed through to pytest (e.g., `-x` for stop-on-first-failure, `-k "pattern"` for filtering).
+
+## When to Use Which Mode
+
+- **After code changes:** `bash test.sh -p` — fast parallel run, verbose output
+- **Quick sanity check:** `bash test.sh -p -q` — minimal output
+- **Before PR / release:** `bash test.sh --ci` — matches CI exactly
+- **Debugging flaky test:** `bash test.sh tests/test_flaky.py` — sequential, single file

--- a/.claude/skills/run-tests/scripts/test.sh
+++ b/.claude/skills/run-tests/scripts/test.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Run pytest with optional parallelism and coverage.
+# Usage: bash test.sh [OPTIONS] [PYTEST_ARGS...]
+#
+# Options:
+#   --parallel, -p    Run with -n auto (pytest-xdist)
+#   --coverage, -c    Enable coverage reporting
+#   --ci              Mimic full CI invocation (-n auto + coverage + xml)
+#   --quick, -q       Quick mode: no coverage, quiet output
+#
+# When --coverage or --ci is passed, this script invokes pytest-cov with --cov
+# (no module spec). pytest-cov / coverage.py then resolve the source set via
+# the standard config lookup — typically [tool.coverage.run] source in
+# pyproject.toml — so the same script works in any sibling without edits.
+#
+# Extra args are passed through to pytest.
+
+set -euo pipefail
+
+PARALLEL=""
+COVERAGE=""
+CI_MODE=""
+QUIET=""
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --parallel|-p) PARALLEL=1; shift ;;
+        --coverage|-c) COVERAGE=1; shift ;;
+        --ci)          CI_MODE=1; shift ;;
+        --quick|-q)    QUIET=1; shift ;;
+        *)             EXTRA_ARGS+=("$1"); shift ;;
+    esac
+done
+
+CMD=(uv run pytest)
+
+if [[ -n "$CI_MODE" ]]; then
+    CMD+=(-n auto --cov --cov-report=xml:coverage.xml --cov-report=term -v)
+elif [[ -n "$QUIET" ]]; then
+    CMD+=(-q)
+    [[ -n "$PARALLEL" ]] && CMD+=(-n auto)
+else
+    [[ -n "$PARALLEL" ]] && CMD+=(-n auto)
+    [[ -n "$COVERAGE" ]] && CMD+=(--cov --cov-report=term)
+    CMD+=(-v)
+fi
+
+CMD+=("${EXTRA_ARGS[@]}")
+
+echo "Running: ${CMD[*]}"
+exec "${CMD[@]}"

--- a/.claude/skills/sonarclaude/SKILL.md
+++ b/.claude/skills/sonarclaude/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: sonarclaude
+type: command
+description: >
+  Query SonarCloud API for code quality data. Use when: checking quality gate status,
+  fetching code issues or security hotspots, reviewing metrics (coverage, bugs, code smells),
+  or the user says "sonar", "quality gate", "code quality", "sonarclaude".
+---
+
+# SonarClaude
+
+Query SonarCloud projects for quality gate status, issues, metrics, and security hotspots.
+
+## Prerequisites
+
+The script requires the following tools on `PATH`:
+
+- `bash`
+- `curl` — talks to the SonarCloud REST API
+- `jq` — parses responses and URL-encodes accept comments
+
+## Environment
+
+Requires `SONAR_TOKEN` environment variable. Set the project key per-repo via
+the `SONAR_PROJECT` environment variable (or pass `--project KEY` on each
+invocation).
+
+## Usage
+
+```bash
+# Quality gate status (pass/fail)
+bash .claude/skills/sonarclaude/scripts/sonar.sh status
+
+# List issues (bugs, vulnerabilities, code smells)
+bash .claude/skills/sonarclaude/scripts/sonar.sh issues
+
+# Filter issues by severity and type
+bash .claude/skills/sonarclaude/scripts/sonar.sh issues --severity CRITICAL --type BUG
+
+# Key metrics (coverage, bugs, code smells, duplication, LOC)
+bash .claude/skills/sonarclaude/scripts/sonar.sh metrics
+
+# Security hotspots
+bash .claude/skills/sonarclaude/scripts/sonar.sh hotspots
+
+# Accept (won't-fix) an OPEN issue with a rationale comment
+bash .claude/skills/sonarclaude/scripts/sonar.sh accept \
+  --issue AZ3Ep83i4ywi8V_l99p0 \
+  --comment "Pushback: rule premise doesn't fit our test fixture pattern."
+
+# Different project
+bash .claude/skills/sonarclaude/scripts/sonar.sh status --project OtherOrg_OtherProject
+
+# Raw JSON output
+bash .claude/skills/sonarclaude/scripts/sonar.sh issues --raw
+
+# Limit results
+bash .claude/skills/sonarclaude/scripts/sonar.sh issues --limit 10
+```
+
+## Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--project` | `$SONAR_PROJECT` | SonarCloud project key |
+| `--severity` | all | Filter: `BLOCKER`, `CRITICAL`, `MAJOR`, `MINOR`, `INFO` |
+| `--type` | all | Filter: `BUG`, `VULNERABILITY`, `CODE_SMELL` |
+| `--limit` | `25` | Max results returned |
+| `--raw` | off | Output raw JSON instead of formatted summary |
+| `--issue` | — | Issue key (required for `accept`) |
+| `--comment` | — | Rationale comment (required for `accept`) |
+
+## When to use `accept`
+
+Sonar rules occasionally flag patterns where the rule's premise does not fit the
+code (e.g. test fixtures with intentional bad-password literals, contradictory
+rule pairs like S7494 vs S7500). After deciding pushback in PR review, run
+`sonar.sh accept` with a rationale comment instead of leaving the issue OPEN —
+this moves it to ACCEPTED/WONTFIX in SonarCloud history (visible to future
+maintainers) while clearing the quality-gate signal. Always include a `--comment`
+explaining why; silent dismissals are not acceptable curation.
+
+Do not call SonarCloud's HTTP API directly from other skills or one-off
+scripts — `sonar.sh accept` is the supported entry point so the rationale
+flow stays consistent.

--- a/.claude/skills/sonarclaude/scripts/sonar.sh
+++ b/.claude/skills/sonarclaude/scripts/sonar.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# SonarCloud API client for Claude Code.
+# Requires SONAR_TOKEN environment variable.
+# Project key resolves from --project flag, then $SONAR_PROJECT.
+
+BASE_URL="https://sonarcloud.io"
+
+# --- Defaults ---
+PROJECT="${SONAR_PROJECT:-}"
+SEVERITY=""
+TYPE=""
+LIMIT=25
+RAW=false
+COMMAND=""
+ISSUE_KEY=""
+ACCEPT_COMMENT=""
+
+require_value() {
+  local flag="$1" remaining="$2"
+  if [[ "$remaining" -lt 2 ]]; then
+    echo "Error: $flag requires a value" >&2
+    echo "Run sonar.sh --help for usage." >&2
+    exit 1
+  fi
+}
+
+# --- Parse args ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    status|issues|metrics|hotspots|accept)
+      COMMAND="$1"; shift ;;
+    --project|-p)   require_value "$1" "$#"; PROJECT="$2";        shift 2 ;;
+    --severity|-s)  require_value "$1" "$#"; SEVERITY="$2";       shift 2 ;;
+    --type|-t)      require_value "$1" "$#"; TYPE="$2";           shift 2 ;;
+    --limit|-l)     require_value "$1" "$#"; LIMIT="$2";          shift 2 ;;
+    --raw|-r)       RAW=true;                                     shift ;;
+    --issue|-i)     require_value "$1" "$#"; ISSUE_KEY="$2";      shift 2 ;;
+    --comment|-c)   require_value "$1" "$#"; ACCEPT_COMMENT="$2"; shift 2 ;;
+    -h|--help)
+      echo "Usage: sonar.sh <command> [options]"
+      echo ""
+      echo "Commands:"
+      echo "  status    Quality gate status (pass/fail)"
+      echo "  issues    List code issues (bugs, vulnerabilities, code smells)"
+      echo "  metrics   Key code metrics (coverage, bugs, duplication, LOC)"
+      echo "  hotspots  Security hotspots"
+      echo "  accept    Mark an OPEN issue as ACCEPTED with a rationale comment"
+      echo ""
+      echo "Options:"
+      echo "  --project, -p KEY       Project key (default: \$SONAR_PROJECT)"
+      echo "  --severity, -s LEVEL    Filter: BLOCKER, CRITICAL, MAJOR, MINOR, INFO"
+      echo "  --type, -t TYPE         Filter: BUG, VULNERABILITY, CODE_SMELL"
+      echo "  --limit, -l N           Max results (default: 25)"
+      echo "  --raw, -r               Output raw JSON"
+      echo "  --issue, -i KEY         Issue key (required for 'accept')"
+      echo "  --comment, -c TEXT      Rationale comment (required for 'accept')"
+      echo "  --help, -h              Show this help"
+      exit 0
+      ;;
+    *) echo "Unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+# --- Validate ---
+if [[ -z "${SONAR_TOKEN:-}" ]]; then
+  echo "Error: SONAR_TOKEN environment variable is not set." >&2
+  exit 1
+fi
+
+if [[ -z "$COMMAND" ]]; then
+  echo "Error: No command provided." >&2
+  echo "Usage: sonar.sh <status|issues|metrics|hotspots|accept> [options]" >&2
+  exit 1
+fi
+
+if [[ -z "$PROJECT" ]]; then
+  echo "Error: No project key. Set \$SONAR_PROJECT or pass --project KEY." >&2
+  exit 1
+fi
+
+# --- API helper ---
+api_get() {
+  local endpoint="$1"
+  curl -s -f -H "Authorization: Bearer $SONAR_TOKEN" "${BASE_URL}${endpoint}"
+}
+
+# --- Commands ---
+
+cmd_status() {
+  local response
+  response=$(api_get "/api/qualitygates/project_status?projectKey=${PROJECT}")
+
+  if [[ "$RAW" == "true" ]]; then
+    echo "$response" | jq .
+    return
+  fi
+
+  local status conditions
+  status=$(echo "$response" | jq -r '.projectStatus.status')
+  conditions=$(echo "$response" | jq -r '.projectStatus.conditions[]? | "  \(.metricKey): \(.actualValue) (threshold: \(.errorThreshold), status: \(.status))"')
+
+  if [[ "$status" == "OK" ]]; then
+    echo "Quality Gate: PASSED"
+  elif [[ "$status" == "ERROR" ]]; then
+    echo "Quality Gate: FAILED"
+  else
+    echo "Quality Gate: $status"
+  fi
+
+  if [[ -n "$conditions" ]]; then
+    echo ""
+    echo "Conditions:"
+    echo "$conditions"
+  fi
+}
+
+cmd_issues() {
+  local params="componentKeys=${PROJECT}&ps=${LIMIT}"
+  [[ -n "$SEVERITY" ]] && params="${params}&severities=${SEVERITY}"
+  [[ -n "$TYPE" ]] && params="${params}&types=${TYPE}"
+
+  local response
+  response=$(api_get "/api/issues/search?${params}")
+
+  if [[ "$RAW" == "true" ]]; then
+    echo "$response" | jq .
+    return
+  fi
+
+  local total
+  total=$(echo "$response" | jq -r '.total')
+  echo "Issues: $total total (showing up to $LIMIT)"
+  echo ""
+
+  echo "$response" | jq -r '.issues[]? | "[\(.severity)] \(.type) — \(.message)\n  File: \(.component | split(":")[1]? // .component)\n  Line: \(.line // "n/a")  Rule: \(.rule)\n"'
+}
+
+# Convert SonarCloud numeric rating to letter grade
+rating_letter() {
+  case "$1" in
+    1|1.0) echo "A" ;;
+    2|2.0) echo "B" ;;
+    3|3.0) echo "C" ;;
+    4|4.0) echo "D" ;;
+    5|5.0) echo "E" ;;
+    *) echo "$1" ;;
+  esac
+}
+
+cmd_metrics() {
+  local metric_keys="bugs,vulnerabilities,code_smells,coverage,duplicated_lines_density,ncloc,sqale_rating,reliability_rating,security_rating,alert_status"
+
+  local response
+  response=$(api_get "/api/measures/component?component=${PROJECT}&metricKeys=${metric_keys}")
+
+  if [[ "$RAW" == "true" ]]; then
+    echo "$response" | jq .
+    return
+  fi
+
+  echo "Metrics for: $PROJECT"
+  echo ""
+
+  echo "$response" | jq -r '.component.measures[]? | "\(.metric): \(.value)"' | while IFS=: read -r key val; do
+    key=$(echo "$key" | xargs)
+    val=$(echo "$val" | xargs)
+    case "$key" in
+      alert_status)
+        echo "  Quality Gate:     $val" ;;
+      bugs)
+        echo "  Bugs:             $val" ;;
+      vulnerabilities)
+        echo "  Vulnerabilities:  $val" ;;
+      code_smells)
+        echo "  Code Smells:      $val" ;;
+      coverage)
+        echo "  Coverage:         ${val}%" ;;
+      duplicated_lines_density)
+        echo "  Duplication:      ${val}%" ;;
+      ncloc)
+        echo "  Lines of Code:    $val" ;;
+      sqale_rating)
+        echo "  Maintainability:  $(rating_letter "$val")" ;;
+      reliability_rating)
+        echo "  Reliability:      $(rating_letter "$val")" ;;
+      security_rating)
+        echo "  Security:         $(rating_letter "$val")" ;;
+      *)
+        echo "  $key: $val" ;;
+    esac
+  done
+}
+
+cmd_hotspots() {
+  local params="projectKey=${PROJECT}&ps=${LIMIT}"
+
+  local response
+  response=$(api_get "/api/hotspots/search?${params}")
+
+  if [[ "$RAW" == "true" ]]; then
+    echo "$response" | jq .
+    return
+  fi
+
+  local total
+  total=$(echo "$response" | jq -r '.paging.total')
+  echo "Security Hotspots: $total total (showing up to $LIMIT)"
+  echo ""
+
+  echo "$response" | jq -r '.hotspots[]? | "[\(.vulnerabilityProbability)] \(.message)\n  File: \(.component | split(":")[1]? // .component)\n  Line: \(.line // "n/a")  Status: \(.status)\n"'
+}
+
+cmd_accept() {
+  if [[ -z "$ISSUE_KEY" ]]; then
+    echo "Error: 'accept' requires --issue KEY" >&2
+    exit 1
+  fi
+  if [[ -z "$ACCEPT_COMMENT" ]]; then
+    echo "Error: 'accept' requires --comment 'rationale text'" >&2
+    exit 1
+  fi
+
+  # 1. Transition issue to ACCEPTED.
+  local transition_resp
+  transition_resp=$(curl -s -H "Authorization: Bearer $SONAR_TOKEN" \
+    -X POST "${BASE_URL}/api/issues/do_transition" \
+    -d "issue=${ISSUE_KEY}&transition=accept")
+
+  local status
+  status=$(echo "$transition_resp" | jq -r '.issue.issueStatus // "UNKNOWN"')
+
+  # 2. Attach rationale comment (URL-encode via jq).
+  local encoded comment_resp comment_status
+  encoded=$(jq -rn --arg s "$ACCEPT_COMMENT" '$s|@uri')
+  comment_resp=$(curl -sS -w $'\n%{http_code}' -H "Authorization: Bearer $SONAR_TOKEN" \
+    -X POST "${BASE_URL}/api/issues/add_comment" \
+    -d "issue=${ISSUE_KEY}&text=${encoded}")
+  comment_status=$(printf '%s\n' "$comment_resp" | tail -n 1)
+  if [[ "$comment_status" -lt 200 || "$comment_status" -ge 300 ]]; then
+    echo "Error: failed to attach rationale comment (HTTP $comment_status)" >&2
+    echo "Response body:" >&2
+    printf '%s\n' "$comment_resp" | sed '$d' >&2
+    exit 1
+  fi
+
+  if [[ "$RAW" == "true" ]]; then
+    echo "$transition_resp" | jq .
+  else
+    echo "Issue $ISSUE_KEY -> $status"
+  fi
+}
+
+# --- Dispatch ---
+case "$COMMAND" in
+  status)   cmd_status   ;;
+  issues)   cmd_issues   ;;
+  metrics)  cmd_metrics  ;;
+  hotspots) cmd_hotspots ;;
+  accept)   cmd_accept   ;;
+  *)        echo "Unknown command: $COMMAND" >&2; exit 1 ;;
+esac

--- a/.claude/skills/spec-to-plan/SKILL.md
+++ b/.claude/skills/spec-to-plan/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: spec-to-plan
+type: command
+description: >
+  Turn a converged devague spec into a buildable plan by working forwards (the
+  spec→plan leg; drives the `devague plan` CLI group). Seed a plan from a
+  converged frame, add tasks that collectively cover every coverage target (the
+  frame's confirmed claims + honesty conditions), give each task acceptance
+  criteria and an honest dependency order, park genuine unknowns as first-class
+  risks, and export a plan only once it *converges*. Use when the user says
+  "spec to plan", "stp", "turn this spec into a plan", "plan this spec", "make a
+  build plan", or after the /think skill exports a spec. Authored and maintained
+  in agentculture/devague (origin = devague); steward pulls this skill from here
+  and broadcasts it to the AgentCulture mesh — it is NOT vendored from steward
+  like the other skills here.
+---
+
+# spec-to-plan — work a converged spec forwards into a buildable plan
+
+The skill is named **`spec-to-plan`**; the product/CLI it drives is the
+**`devague plan`** command group. (The prior leg — turning a vague idea into a
+spec — is the sibling **`/think`** skill.) It is the **forward** peer of the
+working-backwards spec engine: where `/think` converges on *what* to build,
+`/spec-to-plan` converges on *how* to build it.
+
+A plan is seeded from a **converged frame** and tracks **tasks** against the
+spec's **coverage targets**. The CLI is **deterministic and move-driven** — you
+(the agent) choose the next move; the CLI tracks state and tells you what's still
+missing. Run `devague plan learn` for the method and `devague plan explain
+<move>` for any single move.
+
+## How to run
+
+The entry point is `scripts/spec-to-plan.sh`. Invoke it from the repository you
+are speccing (plans persist under `.devague/` in the current directory, alongside
+the frames they derive from):
+
+```bash
+bash .claude/skills/spec-to-plan/scripts/spec-to-plan.sh <move> [args...]
+bash .claude/skills/spec-to-plan/scripts/spec-to-plan.sh status
+```
+
+It resolves the CLI portably — an installed `devague` on `PATH` (the normal
+case), falling back to `uv run devague` inside the devague checkout, else an
+install hint. Every move — including `status` — is forwarded verbatim as
+`devague plan <move>`, so you can equally call the CLI directly
+(`devague plan <move> …`).
+
+### Moves
+
+| Move | What it does |
+|------|--------------|
+| `new --frame <slug>` | Seed a plan from a **converged** frame. Derives the coverage targets (`c*`/`h*`) the plan must satisfy. Refuses an unconverged frame. |
+| `task "<summary>"` | Add a task. `--accept "<crit>"`, `--dep <tN>`, `--covers <c*/h*>` (each repeatable); `--origin llm` lands it `proposed`. |
+| `accept <tN> "<crit>"` | Add an acceptance criterion to a task. |
+| `depend <tN> --on <tM>` | Record that task `tN` depends on `tM`. |
+| `cover <tN> --target <c*/h*>` | Mark a task as covering a coverage target. |
+| `confirm <tN>` / `reject <tN>` | Resolve a task. **User-only decision.** |
+| `risk "<text>" --kind <kind>` | Record a first-class plan risk (`--task <tN>` to attach). |
+| `converge` | Evaluate the gate against the **live** source frame; list remaining gaps. |
+| `export` | Write the buildable plan to `docs/plans/` — only after `converge` passes. |
+| `waves` | Emit deterministic dependency waves (`{plan, waves}`) — scheduling metadata only, *not* orchestration. Read-only, works on an in-progress plan; refuses a cyclic/dangling graph. Devague describes the graph; an operator decides how to run it (#20). |
+| `status` | Read-only: where the plan stands + the recommended next move, re-checked against the live frame (`--json` too). |
+| `show` / `list` | Render a plan / list plans (`--json` for raw state). |
+| `learn` / `explain <move>` | Teach the method / explain one move. |
+
+Risk kinds (shared with the frame engine): `unknown_nonblocking`,
+`unknown_blocking`, `out_of_scope`, `follow_up`.
+
+### `status` — the next-move verb
+
+`status` is a first-class, **read-only** CLI verb (`devague plan status`,
+internalised from this wrapper in 0.11.0 — issue
+[#30](https://github.com/agentculture/devague/issues/30)). It composes
+`devague plan list` + `devague plan converge` and prints where the current plan
+stands, the remaining gaps, and the recommended next move derived from the first
+gap. Like `converge`/`export` it re-checks the **live** source frame (so frame
+drift surfaces as an error), but it never mutates state. Pass `--json` for the
+structured payload (`{plan, total, ready_for_plan, blockers, warnings,
+parked_items, required_next_moves}`).
+
+```text
+plan: my-feature    (1 plan total)
+convergence: NOT passed — 2 gap(s):
+  - coverage target c5 (boundary) has no confirmed task
+  - task t2 has no acceptance criteria
+
+recommended next move (first gap):
+  cover c5: devague plan task "<summary>" --covers c5 --accept "<...>"
+```
+
+Run it whenever you're unsure what to do next.
+
+## Hard rules (do not violate)
+
+These are the point of the method — convergence must mean something.
+
+- **Seed from a converged spec only.** `plan new` refuses a frame that hasn't
+  converged. The plan's coverage targets *are* the spec's confirmed claims and
+  honesty conditions — there is nothing honest to plan against until the spec
+  converges.
+- **LLM proposals stay proposed.** A task captured with `--origin llm` lands as
+  `proposed`. **Never `confirm` your own proposal.** Confirmation is a user-only
+  decision — surface the proposed task and let the user confirm or reject it.
+- **Cover every target; criteria on every task.** The gate requires every
+  coverage target to be covered by a confirmed task, and every confirmed task to
+  carry at least one acceptance criterion. Don't hand-wave a task as "done-ish."
+- **Keep the graph honest.** Dependencies must reference real tasks and form an
+  acyclic graph; the gate rejects dangling deps and cycles.
+- **Park real unknowns as risks; don't paper over them.** A genuinely unknown
+  decision is an `unknown_blocking` risk — it holds back convergence, by design.
+- **Converge against the live frame.** `converge`/`export` re-load the source
+  frame every time. If the frame was deleted or has regressed below convergence,
+  they refuse — re-converge the spec (in `/think`) first.
+
+## Coaching toward small, file-disjoint, TDD-gated tasks
+
+When authoring a plan that will be built via parallel execution (fanned out to
+multiple agents via the downstream `/assign-to-workforce` skill), prefer the
+following discipline to maximize parallelism and minimize merge friction:
+
+### Small and crisply scoped
+
+Each task should be **small enough for a simpler or cheaper model to build
+test-first** without re-deriving the full design. If a task spans multiple files
+or architectural layers, split it — narrow scope forces you to write sharp
+acceptance criteria and keeps waves wide.
+
+### File disjoint
+
+**Prefer tasks that touch non-overlapping files.** When two same-wave tasks
+modify the same file, merge collision becomes inevitable. The dependency graph
+alone *does not* guarantee file disjointness — it only sequences task *content*
+dependencies; same-wave tasks with overlapping file-writes must be split across
+waves or given explicit dependencies.
+
+Check `devague plan waves` output: if a wave is wide but all tasks touch
+`src/core.py`, the wave is *formally* parallel but *operationally* serialized at
+merge. Reorder task boundaries so wide waves operate on disjoint file sets.
+
+### TDD acceptance criteria on every task
+
+Every confirmed task must carry **at least one acceptance criterion**, phrased as
+a testable condition (not a vague outcome). For example:
+
+- Bad: "Implement the parser"
+- Better: "Parser accepts a valid spec file and rejects malformed YAML without
+  data loss"
+
+Acceptance criteria are **the contract** between the main agent (who merges) and
+the subagent (who builds). A test suite derived from these criteria validates
+each task's output *before* merge, independent of model capability. This is not
+optional: `devague plan converge` warns (non-blocking) when a confirmed task
+lacks criteria.
+
+### The key invariant: parallel = serial
+
+**A plan built in parallel must yield identical results to building it serially.**
+This is guaranteed only if:
+
+1. Same-wave tasks have no inter-task dependencies (checked by `waves`).
+2. Same-wave tasks touch disjoint files (you must verify; the CLI does not).
+3. Each task's acceptance criteria are sharp enough that a subagent's output
+   passes them independent of whether it was built in isolation or alongside
+   other tasks.
+
+The TDD gate — tests pass before *and* after the merge — is the main agent's
+proof that parallelism didn't break correctness.
+
+### How to route tasks to the workforce
+
+Once your plan converges, `devague plan waves` emits the dependency-graph as
+**scheduling metadata** (ordered batches of task IDs). This feeds directly into
+the `/assign-to-workforce` skill, which:
+
+1. Displays the plan, waves, and suggested per-task subagent/model pairing.
+2. Waits for the human to approve the implementation split plan (or edit
+   assignments).
+3. Fans out approved waves to isolated subagent worktrees (one per task per
+   wave).
+4. Returns control to the main agent, which TDD-gates each merge before moving
+   to the next wave.
+
+Plan for workforce execution early: narrow task scope, write crisp acceptance
+criteria, and strive for wide waves with disjoint files.
+
+## Output contract
+
+Results go to **stdout**, diagnostics and errors to **stderr** — a strict split
+you can rely on when parsing. Pass `--json` to any move for a structured payload.
+Exit code `0` on success, non-zero on user error (with a `hint:` line). Plans
+live under `.devague/plans/` in the current directory; the exported plan-md lands
+in `docs/plans/`.
+
+## Worked example
+
+Picking up after `/think` exported a spec for the frame `my-feature`:
+
+```bash
+p() { bash .claude/skills/spec-to-plan/scripts/spec-to-plan.sh "$@"; }
+
+p new --frame my-feature        # seeds the plan + its coverage targets
+p show                          # see the c*/h* targets you must cover
+
+p task "Build the core engine" --accept "engine has a convergence gate" \
+    --covers c1 --covers c3
+p task "Pressure-test honesty conditions" --dep t1 --covers h1 --covers h2 \
+    --accept "every honesty condition maps to a test"
+
+# Park a genuine unknown instead of guessing:
+p risk "exact rollout sequencing" --kind unknown_nonblocking
+
+p status        # what's left + the next move
+p converge      # gate; resolve any listed gaps
+p export        # writes docs/plans/my-feature.md once converged
+```
+
+The exported plan-md is a buildable artifact: topologically ordered tasks, each
+with acceptance criteria and the spec targets it covers. It feeds directly into
+implementation (or `superpowers:writing-plans`).
+
+## Provenance
+
+This is a **first-party** skill — its origin is `agentculture/devague`, where the
+devague agent maintains it alongside the tool it operates (dogfooding), next to
+its sibling `/think`. It is the *inverse* of the other skills under
+`.claude/skills/`, which devague vendors **from** steward. When ready, steward
+pulls it **from** devague and broadcasts it to the rest of the AgentCulture mesh.
+The `cite, don't import` policy still holds: downstream repos copy it, they don't
+symlink or depend on it. See `docs/skill-sources.md`.

--- a/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
+++ b/.claude/skills/spec-to-plan/scripts/spec-to-plan.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# spec-to-plan.sh — drive devague's spec→plan engine (the /spec-to-plan skill).
+#
+# The skill is named `spec-to-plan`; the product/CLI it drives is `devague` (the
+# idea→spec half lives in the sibling /think skill). This wrapper forwards every
+# move to `devague plan <move>` verbatim — including the `status` verb the CLI
+# internalised in 0.11.0 (devague#30/#31), which reads the plan convergence gate
+# and names the recommended next move. It is the forward leg: seed a plan from a
+# *converged* frame, then work it into a buildable plan.
+#
+# Origin: authored and maintained in agentculture/devague. steward pulls this
+# skill from here and broadcasts it to the rest of the AgentCulture mesh, so it
+# is written to run anywhere — portable bash, no devague-checkout assumptions.
+#
+# Plans persist under .devague/ in the current directory (alongside frames), so
+# run from the repo you are speccing.
+
+set -euo pipefail
+
+# ── resolve the devague CLI (mesh-first, then local-dev fallback) ───────────
+DEVAGUE=()
+resolve_devague() {
+    if command -v devague >/dev/null 2>&1; then
+        DEVAGUE=(devague)            # installed tool — the normal mesh case
+        return 0
+    fi
+    # Local-dev fallback: inside the devague checkout, run via uv.
+    local dir="$PWD"
+    while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+        if [ -f "$dir/pyproject.toml" ] \
+            && grep -q '^name = "devague"' "$dir/pyproject.toml" 2>/dev/null; then
+            if command -v uv >/dev/null 2>&1; then
+                DEVAGUE=(uv run devague)
+                return 0
+            fi
+            break
+        fi
+        dir=$(dirname "$dir")
+    done
+    cat >&2 <<'EOF'
+error: devague CLI not found.
+hint: install it with `uv tool install devague` (or `pipx install devague`),
+      or run from inside the devague checkout with `uv` available.
+      https://github.com/agentculture/devague
+EOF
+    return 1
+}
+
+usage() {
+    cat <<'EOF'
+spec-to-plan.sh — drive devague's spec→plan engine (the /spec-to-plan skill).
+
+Usage:
+  spec-to-plan.sh <move> [args...]   forward a `devague plan` move
+  spec-to-plan.sh status [--plan S]  where the plan stands + the next move
+  spec-to-plan.sh help               this help
+
+Moves (forwarded to `devague plan`; run `devague plan learn` for the method):
+  new          start a plan from a CONVERGED frame (--frame <slug>)
+  task         add a task (--accept / --dep / --covers, --origin user|llm)
+  accept       add an acceptance criterion to a task
+  depend       record that a task depends on another (--on)
+  cover        mark a task as covering a coverage target (c*/h*)
+  confirm      confirm a task                          (USER-only decision)
+  reject       reject a task
+  risk         record a first-class plan risk
+  converge     check whether the plan can export
+  export       write the buildable plan (only after converge passes)
+  waves        emit deterministic dependency waves (scheduling metadata, not orchestration)
+  status       where the plan stands + the recommended next move
+  show / list  render a plan / list plans
+  learn        teach the method   |   explain <move>  explain one move
+
+Plans persist under .devague/ in the current directory — run from the repo you
+are speccing. Results go to stdout, diagnostics to stderr; pass --json to any
+move for structured output.
+
+Note: every move — including `status` — is forwarded verbatim as `devague plan
+<move>`, so new plan moves work without editing this script. (`status` was
+internalised into the CLI in devague 0.11.0; it is no longer wrapper-only.)
+
+Prior leg: a plan is seeded from a converged frame produced by the /think skill.
+EOF
+}
+
+main() {
+    case "${1:-help}" in
+        help | -h | --help)
+            usage
+            return 0
+            ;;
+        *)
+            # Forward every move to `devague plan <move>` verbatim — including the
+            # internalised `status` verb (`devague plan status`) — so the CLI's own
+            # parser owns the plan surface.
+            resolve_devague
+            exec "${DEVAGUE[@]}" plan "$@"
+            ;;
+    esac
+}
+
+main "$@"

--- a/.claude/skills/think/SKILL.md
+++ b/.claude/skills/think/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: think
+type: command
+description: >
+  Think a vague feature idea into a buildable spec by working backwards (the
+  idea→spec leg; drives the `devague` CLI). Start from the announcement
+  ("pretend it shipped"), capture and classify claims, interrogate them with
+  honesty conditions and hard questions, park open vagueness as a first-class
+  object, and export a spec only once the frame *converges*. Use when the user
+  says "think this through", "spec this", "work backwards", "turn this idea into
+  a spec", "announcement frame", or "devague", or when a feature request is too
+  vague to build yet. Once a spec exports, hand off to the sibling /spec-to-plan
+  skill to turn it into a plan. Authored and maintained in agentculture/devague
+  (origin = devague); steward pulls this skill from here and broadcasts it to the
+  AgentCulture mesh — it is NOT vendored from steward like the other skills here.
+---
+
+# think — work an idea backwards into a buildable spec
+
+The skill is named **`think`**; the product/CLI it drives is **`devague`**. (The
+forward leg — turning a converged spec into a plan — is the sibling
+**`/spec-to-plan`** skill, which drives `devague plan`.)
+
+`think` turns a vague feature idea into a buildable spec by **working
+backwards**: you start from the announcement you'd make if it had already
+shipped, then build an **Announcement Frame** by capturing claims, pressure
+-testing them, parking what's still genuinely unknown, and only exporting once
+the frame converges.
+
+The CLI is **deterministic and move-driven** — it is *not* a wizard. There is no
+fixed sequence of prompts. **You (the agent) choose the next move; the CLI just
+tracks state and tells you what's still missing.** Run `devague learn` for the
+canonical ten-stage arc and `devague explain <move>` for any single move.
+
+This skill is the operator: a portable wrapper that resolves the CLI and
+forwards every move verbatim — including `status`, the read-only verb that reads
+the convergence gate and tells you the recommended next move.
+
+## How to run
+
+The entry point is `scripts/think.sh`. Invoke it from the repository you are
+speccing (frames persist under `.devague/` in the current directory):
+
+```bash
+bash .claude/skills/think/scripts/think.sh <move> [args...]
+bash .claude/skills/think/scripts/think.sh status
+```
+
+It resolves the CLI portably — an installed `devague` on `PATH` (the normal
+case), falling back to `uv run devague` when you are inside the devague checkout.
+If neither resolves it prints an install hint (`uv tool install devague`). Every
+move — including `status` — is forwarded verbatim, so you can equally call the
+CLI directly (`devague <move> …`) when it is installed; the wrapper exists only
+for portable resolution.
+
+### Moves
+
+| Move | What it does |
+|------|--------------|
+| `new "<announcement>"` | Start a frame from the announcement (the first move). Seeds an auto-confirmed `announcement` claim. |
+| `capture --kind <kind> "<text>"` | Record + classify a claim. `--origin llm` lands it as `proposed`. |
+| `interrogate <id> --honesty "…"` | Attach an honesty condition (what must be true). Also `--hard-question`, `--risk`, `--contradicts`, `--blocking`. |
+| `confirm <id> [<id>…]` / `reject <id> [<id>…]` | Resolve one or more claims (`c*`) / honesty conditions (`h*`) in one **transactional** call. **User-only decision.** Also `confirm --from-review <file>` to apply an edited review artifact. |
+| `review` | List every **proposed** (unconfirmed) claim + honesty condition with ids (`--json` too); writes a non-authoritative artifact to `.devague/reviews/<slug>.md`. Un-gated; never mutates. |
+| `question "<text>"` | Record / list / `--resolve` a pending user decision as durable working state in `.devague/questions/<slug>.md`. |
+| `park "<text>" --kind <kind>` | Move uncertainty into first-class open vagueness instead of forcing an answer. |
+| `converge` | Evaluate the gate; list remaining gaps. |
+| `export` | Write the buildable spec to `docs/specs/` — only after `converge` passes. |
+| `status` | Read-only: where the frame stands + the recommended next move (`--json` too). |
+| `show` / `list` | Render a frame / list frames (`--json` for raw state). |
+| `learn` / `explain <move>` | Teach the method / explain one move. |
+
+Claim kinds: `announcement`, `audience`, `after_state`, `before_state`,
+`why_it_matters`, `boundary`, `success_signal`, `open_question`, `non_goal`,
+`requirement`, `assumption`, `decision`. Vagueness kinds: `unknown_nonblocking`,
+`unknown_blocking`, `out_of_scope`, `follow_up`.
+
+These are exactly the kinds the **shipped CLI enforces** (`CLAIM_KINDS` /
+`VAGUENESS_KINDS` in `devague/frame.py`) — the skill documents the surface as
+built, so every command here passes the CLI's `choices=` validation. `requirement`
+is spec-affecting (needs a confirmed honesty condition); `non_goal` / `decision`
+are descriptive; an unconfirmed `assumption` is a convergence *warning*, not a
+blocker. The formal entity model, the `(state × origin)` vocabulary, and the
+per-move input/output/transition/error contract are documented in
+[`docs/spec-contract.md`](../../../docs/spec-contract.md) (issue
+[#5](https://github.com/agentculture/devague/issues/5)); for the authoritative
+live shape of any move, run it with `--json` (or `devague learn --json` /
+`devague explain <move>`).
+
+### `status` — the next-move verb
+
+`status` is a first-class, **read-only** CLI verb (`devague status`, internalised
+from this wrapper in 0.11.0 — issue
+[#30](https://github.com/agentculture/devague/issues/30)). It composes
+`list` + `converge` and prints where the current frame stands, the remaining
+gaps, and the recommended next move; it never mutates state (the
+`drafting`↔`converged` transition stays in `converge`). It reports
+`ready_for_spec`, lists the `blockers` and `warnings`, and shows
+`required_next_moves[0]` as the recommended move. Pass `--json` for the same
+fields as a structured payload (`{frame, total, ready_for_spec, blockers,
+warnings, parked_items, required_next_moves}`).
+
+```text
+frame: my-feature    (1 frame total)
+convergence: NOT passed — 2 gap(s):
+  - missing a 'boundary' / non-goal claim
+  - claim c2 has no confirmed honesty condition
+
+recommended next move (first gap):
+  devague capture --kind boundary "<text>"
+```
+
+Run it whenever you're unsure what to do next.
+
+## Hard rules (do not violate)
+
+These are the point of the method — convergence must mean something.
+
+- **LLM proposals stay proposed.** A claim captured with `--origin llm`, and any
+  honesty condition you (the agent) propose, lands as `proposed`. **Never
+  `confirm` your own proposal.** Confirmation is a user-only decision — surface
+  the proposal and let the user confirm or reject it. Proposed content must not
+  silently become an authoritative requirement.
+- **Honesty conditions route through the user.** Propose them freely with
+  `interrogate --honesty`; the user owns whether they hold.
+- **Converge, don't vibe.** `export` is gated on `converge` passing. Never claim
+  the frame is ready on a hunch — run `converge` (or `status`) and resolve every
+  listed gap. The gate requires confirmed `announcement` / `audience` /
+  `after_state`, a `before_state` or `why_it_matters`, a `boundary`, a
+  `success_signal`, a confirmed honesty condition on every spec-affecting claim,
+  and no unresolved blocking vagueness or hard question.
+- **Park real unknowns; don't paper over them.** If something is genuinely
+  unknown, `park` it (blocking or non-blocking) rather than fabricating an
+  answer. Blocking vagueness holds back convergence — by design.
+
+## Output contract
+
+Results go to **stdout**, diagnostics and errors to **stderr** — a strict split
+you can rely on when parsing. Pass `--json` to any move for a structured payload
+on the same stream. Exit code `0` on success, non-zero on user error (with a
+`hint:` line). Frames live under `.devague/` in the current directory.
+
+## Worked example
+
+A short end-to-end session (the kind you'd run to spec a feature like
+[devague#5](https://github.com/agentculture/devague/issues/5)):
+
+```bash
+d() { bash .claude/skills/think/scripts/think.sh "$@"; }
+
+d new "Devague ships a documented spec contract"
+d capture --kind audience "devague + the assisting LLM"
+d capture --kind after_state "a vague idea becomes a buildable, pressure-tested spec"
+d capture --kind why_it_matters "specs converge on evidence, not vibes"
+d capture --kind boundary "not a full PRD generator; no fixed wizard"
+d capture --kind success_signal "a frame exports only after the gate passes"
+
+# Pressure-test a claim, then let the USER confirm the condition:
+d interrogate c1 --honesty "the contract round-trips: save -> load -> identical frame"
+# ...user reviews and runs: d confirm h1
+
+# Park a genuine unknown instead of guessing:
+d park "exact JSON schema versioning policy" --kind unknown_nonblocking
+
+d status        # what's left + the next move
+d converge      # gate; resolve any listed gaps
+d export        # writes docs/specs/<slug>.md once converged
+```
+
+The exported spec-md is a buildable artifact.
+
+## After export — commit, then hand off
+
+Once `export` writes the spec **and the user has reviewed it**, close the
+idea→spec leg cleanly before moving on:
+
+1. **Commit the spec.** Commit the exported `docs/specs/<slug>.md` (along with
+   the `.devague/<slug>.json` frame state and any review artifact under
+   `docs/reviews/`) so the converged frame is durable in history, not just on
+   disk. Use a focused message, e.g. `git commit -m "spec: <slug> (devague
+   /think)"`. The frame and the spec are the evidence trail for every confirmed
+   claim — keep them together. (Per the repo's standing convention this normally
+   becomes a branch + PR via the `cicd` skill; commit-only is fine when the user
+   asks for it.)
+2. **Hand off to `/spec-to-plan`.** The forward leg is the sibling skill:
+   `devague plan new --frame <slug>` seeds a plan from the converged frame and
+   works it forward into a buildable plan (it can equally feed
+   `superpowers:writing-plans` or a normal implementation PR).
+
+Don't pause for a "what next?" menu after a reviewed export — the standing flow
+is **commit, then `/spec-to-plan`**.
+
+## Provenance
+
+This is a **first-party** skill — its origin is `agentculture/devague`, where the
+devague agent maintains it alongside the tool it operates (dogfooding). It is the
+*inverse* of the other skills under `.claude/skills/`, which devague vendors
+**from** steward. When this skill is ready, steward pulls it **from** devague and
+broadcasts it to the rest of the AgentCulture mesh. The `cite, don't import`
+policy still holds: downstream repos copy it, they don't symlink or depend on it.
+See `docs/skill-sources.md`.

--- a/.claude/skills/think/scripts/think.sh
+++ b/.claude/skills/think/scripts/think.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# think.sh — drive devague's working-backwards idea→spec engine (the /think skill).
+#
+# The skill is named `think`; the product/CLI it drives is `devague` (the spec→plan
+# half lives in the sibling /spec-to-plan skill, which drives `devague plan`).
+# devague turns a vague feature idea into a buildable spec by working backwards.
+# This wrapper is the agent-facing operator for the deterministic devague CLI:
+# it resolves the CLI portably and forwards every move verbatim — including the
+# `status` verb the CLI internalised in 0.11.0 (devague#30/#31), which reads the
+# convergence gate and names the recommended next move.
+#
+# Origin: authored and maintained in agentculture/devague. steward pulls this
+# skill from here and broadcasts it to the rest of the AgentCulture mesh, so it
+# is written to run anywhere — portable bash, no devague-checkout assumptions.
+#
+# Frames persist under .devague/ in the current directory, so run from the repo
+# you are speccing.
+
+set -euo pipefail
+
+# ── resolve the devague CLI (mesh-first, then local-dev fallback) ───────────
+DEVAGUE=()
+resolve_devague() {
+    if command -v devague >/dev/null 2>&1; then
+        DEVAGUE=(devague)            # installed tool — the normal mesh case
+        return 0
+    fi
+    # Local-dev fallback: inside the devague checkout, run via uv.
+    local dir="$PWD"
+    while [ -n "$dir" ] && [ "$dir" != "/" ]; do
+        if [ -f "$dir/pyproject.toml" ] \
+            && grep -q '^name = "devague"' "$dir/pyproject.toml" 2>/dev/null; then
+            if command -v uv >/dev/null 2>&1; then
+                DEVAGUE=(uv run devague)
+                return 0
+            fi
+            break
+        fi
+        dir=$(dirname "$dir")
+    done
+    cat >&2 <<'EOF'
+error: devague CLI not found.
+hint: install it with `uv tool install devague` (or `pipx install devague`),
+      or run from inside the devague checkout with `uv` available.
+      https://github.com/agentculture/devague
+EOF
+    return 1
+}
+
+usage() {
+    cat <<'EOF'
+think.sh — drive devague's working-backwards idea→spec engine (the /think skill).
+
+Usage:
+  think.sh <move> [args...]    forward a devague move
+  think.sh status [--frame S]  where the frame stands + the next move
+  think.sh help                this help
+
+Moves (forwarded to the devague CLI; run `devague learn` for the full method):
+  new          start a frame from the announcement ("pretend it shipped")
+  capture      record + classify a claim (--kind audience|after_state|...)
+  interrogate  pressure-test a claim (--honesty / --hard-question / --risk)
+  confirm      confirm a claim or honesty condition  (USER-only decision)
+  reject       reject a claim or honesty condition
+  park         record open vagueness instead of forcing an answer
+  converge     check whether the frame can export a spec
+  export       write the buildable spec (only after converge passes)
+  status       where the frame stands + the recommended next move
+  show / list  render a frame / list frames
+  learn        teach the method   |   explain <move>  explain one move
+
+Frames persist under .devague/ in the current directory — run from the repo
+you are speccing. Results go to stdout, diagnostics to stderr; pass --json to
+any move for structured output.
+
+Note: every move — including `status` — is forwarded verbatim to the devague
+CLI, so new devague moves work without editing this script. (`status` was
+internalised into the CLI in devague 0.11.0; it is no longer wrapper-only.)
+
+Next leg: once a frame exports a spec, hand off to the /spec-to-plan skill
+(`devague plan ...`) to turn that spec into a buildable plan.
+EOF
+}
+
+main() {
+    case "${1:-help}" in
+        help | -h | --help)
+            usage
+            return 0
+            ;;
+        *)
+            # Forward every move to the CLI verbatim (including --version, the
+            # internalised `status` verb, and any future devague move), so its
+            # own parser owns the surface.
+            resolve_devague
+            exec "${DEVAGUE[@]}" "$@"
+            ;;
+    esac
+}
+
+main "$@"

--- a/.claude/skills/version-bump/SKILL.md
+++ b/.claude/skills/version-bump/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: version-bump
+type: command
+description: >
+  Bump the semver version in pyproject.toml (major, minor, or patch) and
+  prepend a Keep-a-Changelog entry to CHANGELOG.md. Use when preparing a
+  release, before creating a PR (the version-check CI job blocks merge if
+  you don't), or when the user says "bump version", "release", or
+  "increment version".
+---
+
+# Version Bump
+
+Bump the semver version in `pyproject.toml` and prepend a new entry to
+`CHANGELOG.md`. Mirrors the AgentCulture workflow used by `culture`,
+`afi-cli`, `cfafi`, and other org repos; vendored here so the repo is
+self-contained.
+
+## Usage
+
+Run from the repo root.
+
+```bash
+# With changelog content (pipe JSON via stdin):
+echo '{"added":["New X"],"changed":["Refactored Y"],"fixed":["Bug in Z"]}' \
+  | python3 .claude/skills/version-bump/scripts/bump.py minor
+
+# Without changelog content (inserts empty ### Added/Changed/Fixed stubs):
+python3 .claude/skills/version-bump/scripts/bump.py patch
+
+# Check current version without bumping:
+python3 .claude/skills/version-bump/scripts/bump.py show
+```
+
+## Bump Types
+
+| Type    | Example        | When to use                                                       |
+|---------|----------------|-------------------------------------------------------------------|
+| `major` | 0.1.0 → 1.0.0  | Breaking changes, namespace restructures, CLI surface breaks      |
+| `minor` | 0.1.0 → 0.2.0  | New features, new commands, new modules                           |
+| `patch` | 0.1.0 → 0.1.1  | Bug fixes, doc updates, dependency bumps, CI-only changes         |
+| `show`  | prints `0.1.0` | Read-only — no files changed                                      |
+
+## Changelog JSON Format
+
+Pass via stdin. All fields are optional — only non-empty sections are rendered.
+
+```json
+{
+  "added":   ["List of new features"],
+  "changed": ["List of changes to existing functionality"],
+  "fixed":   ["List of bug fixes"]
+}
+```
+
+## What it touches
+
+- `pyproject.toml` — the `version = "x.y.z"` field (single source of truth;
+  `steward/__init__.py` reads it via `importlib.metadata`, so there's no
+  separate `__version__` literal to keep in sync).
+- `CHANGELOG.md` — inserts a new `## [x.y.z] - YYYY-MM-DD` entry at the top.
+
+The script does the rest. Pick a bump type from the diff (patch for fixes,
+minor for new features, major for breaking changes), summarize the diff into
+`added` / `changed` / `fixed` lists, pipe as JSON, and commit the resulting
+`pyproject.toml` + `CHANGELOG.md` alongside the code change so the
+`version-check` CI job sees a consistent bump.

--- a/.claude/skills/version-bump/scripts/bump.py
+++ b/.claude/skills/version-bump/scripts/bump.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Bump the version in pyproject.toml and CHANGELOG.md.
+
+If the package's ``__init__.py`` contains a literal ``__version__ = "..."``
+assignment, the script also rewrites that value. In repos that read
+``__version__`` from package metadata (the steward-cli convention), the
+``__init__.py`` step is a no-op.
+
+Usage:
+    bump.py major    # 0.1.0 -> 1.0.0
+    bump.py minor    # 0.1.0 -> 0.2.0
+    bump.py patch    # 0.1.0 -> 0.1.1
+    bump.py show     # print current version
+
+Changelog entries are passed via stdin as a JSON object:
+    {
+      "added": ["New CLI command", "Observer module"],
+      "changed": ["Restructured namespace"],
+      "fixed": ["WHO reply index bug"]
+    }
+
+If no stdin is provided, an empty stub is inserted.
+"""
+
+import json
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+
+def find_pyproject() -> Path:
+    """Walk up from cwd to find pyproject.toml."""
+    current = Path.cwd()
+    while current != current.parent:
+        candidate = current / "pyproject.toml"
+        if candidate.exists():
+            return candidate
+        current = current.parent
+    print("ERROR: pyproject.toml not found", file=sys.stderr)
+    sys.exit(1)
+
+
+def read_version(path: Path) -> str:
+    """Extract version string from pyproject.toml."""
+    text = path.read_text()
+    match = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if not match:
+        print("ERROR: version field not found in pyproject.toml", file=sys.stderr)
+        sys.exit(1)
+    return match.group(1)
+
+
+def bump(version: str, part: str) -> str:
+    """Bump the specified part of a semver version."""
+    parts = version.split(".")
+    if len(parts) != 3:
+        print(f"ERROR: version '{version}' is not semver (x.y.z)", file=sys.stderr)
+        sys.exit(1)
+
+    major, minor, patch = int(parts[0]), int(parts[1]), int(parts[2])
+
+    if part == "major":
+        return f"{major + 1}.0.0"
+    elif part == "minor":
+        return f"{major}.{minor + 1}.0"
+    elif part == "patch":
+        return f"{major}.{minor}.{patch + 1}"
+    else:
+        print(f"ERROR: unknown bump type '{part}' (use major, minor, or patch)", file=sys.stderr)
+        sys.exit(1)
+
+
+def write_version(path: Path, old: str, new: str) -> None:
+    """Replace old version with new in pyproject.toml."""
+    text = path.read_text()
+    updated = text.replace(f'version = "{old}"', f'version = "{new}"', 1)
+    path.write_text(updated)
+
+
+def read_changelog_entries() -> dict:
+    """Read changelog entries from stdin as JSON."""
+    if sys.stdin.isatty():
+        return {}
+    try:
+        raw = sys.stdin.read().strip()
+        if not raw:
+            return {}
+        return json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        print("WARNING: could not parse changelog JSON from stdin, using empty stub", file=sys.stderr)
+        return {}
+
+
+def format_changelog_section(new: str, entries: dict) -> str:
+    """Format a changelog section from entries dict.
+
+    Output uses single blank lines between elements (markdownlint MD012
+    compliant). Trailing blank line before the next existing entry is
+    included.
+    """
+    today = date.today().isoformat()
+    chunks = [f"## [{new}] - {today}\n"]
+
+    for section in ("added", "changed", "fixed"):
+        items = entries.get(section, [])
+        if items:
+            chunks.append(f"\n### {section.capitalize()}\n\n")
+            chunks.extend(f"- {item}\n" for item in items)
+
+    # If no entries at all, emit empty section stubs.
+    if not any(entries.get(s) for s in ("added", "changed", "fixed")):
+        chunks.append("\n### Added\n\n### Changed\n\n### Fixed\n")
+
+    chunks.append("\n")  # blank line before the next existing entry
+    return "".join(chunks)
+
+
+def update_changelog(project_root: Path, new: str, entries: dict) -> None:
+    """Insert a new changelog entry into CHANGELOG.md."""
+    changelog = project_root / "CHANGELOG.md"
+    if not changelog.exists():
+        print("No CHANGELOG.md found — skipping")
+        return
+
+    text = changelog.read_text()
+    new_entry = format_changelog_section(new, entries)
+
+    marker = "## ["
+    idx = text.find(marker)
+    if idx > 0:
+        changelog.write_text(text[:idx] + new_entry + text[idx:])
+        print(f"Updated CHANGELOG.md with [{new}]")
+    else:
+        print("WARNING: could not find insertion point in CHANGELOG.md", file=sys.stderr)
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
+        print(__doc__.strip())
+        sys.exit(0)
+
+    part = sys.argv[1].lower()
+    path = find_pyproject()
+    current = read_version(path)
+
+    if part == "show":
+        print(current)
+        sys.exit(0)
+
+    # Read changelog entries before bumping
+    entries = read_changelog_entries()
+
+    new = bump(current, part)
+    write_version(path, current, new)
+
+    # Also update __init__.py if it has __version__
+    init_candidates = [
+        path.parent / path.parent.name / "__init__.py",
+    ]
+    for init in init_candidates:
+        if init.exists():
+            init_text = init.read_text()
+            if f'__version__ = "{current}"' in init_text:
+                init.write_text(init_text.replace(
+                    f'__version__ = "{current}"',
+                    f'__version__ = "{new}"',
+                ))
+                print(f"Updated {init.relative_to(path.parent)}")
+
+    # Update changelog
+    update_changelog(path.parent, new, entries)
+
+    print(f"{current} -> {new}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,13 @@ htmlcov/
 
 
 .env
+
+# Local agent-tooling state (devex PR lifecycle + teken)
+.teken/
+.devex/
+
+# Per-machine skills config (copy from skills.local.yaml.example)
+skills.local.yaml
+
+# Claude Code per-machine local settings (not shared)
+.claude/settings.local.json

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,23 @@
+# markdownlint-cli2 config for reachy-mini-mcp.
+# markdownlint-cli2 stops walking at the git root, so a per-user global config
+# in the home directory isn't picked up from inside the repo.
+# Mirrors the guildmaster / steward / teken preset for workspace consistency.
+
+config:
+  default: true
+  # MD013: Line length — disabled. Prose lines wrap at the reader.
+  MD013: false
+  # MD060: Table pipe spacing — disabled (stylistic preference).
+  MD060: false
+  # MD024: Duplicate headings — allow under different parents so Keep a
+  # Changelog entries can each have ### Added / ### Changed / ### Fixed.
+  MD024:
+    siblings_only: true
+
+ignores:
+  - "node_modules/**"
+  - ".local/**"
+  - ".afi/**"
+  - ".teken/**"
+  # Vendored skills are cited verbatim from guildmaster — do not reformat them.
+  - ".claude/skills/**"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,128 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this project is
+
+`reachy-mini-mcp` is a **Model Context Protocol (MCP) server for controlling the
+[Reachy Mini](https://github.com/pollen-robotics/reachy_mini) expressive robot**
+(Pollen Robotics), built on [FastMCP](https://github.com/jlowin/fastmcp). It lets
+an MCP client (Claude Desktop, an agent, etc.) drive the robot's head, antennas,
+emotions, and gestures, and speak through a text-to-speech queue.
+
+The server exposes a **single meta-tool**, `operate_robot`, rather than one MCP tool
+per action (`server.py:612` registers only `operate_robot`). Call it with a single
+action or a sequence:
+
+```python
+operate_robot(tool_name="express_emotion", parameters={"emotion": "happy", "speech": "Hello!"})
+operate_robot(commands=[{"tool_name": "turn_on_robot"}, {"tool_name": "nod_head"}])
+```
+
+A `"speech"` parameter on any command is spoken aloud via the TTS queue. The server
+also publishes MCP resources (`reachy://status`, `reachy://capabilities`) and prompts.
+
+As of this onboarding the repo is also an **AgentCulture mesh agent** (see Identity).
+
+## Identity
+
+Declared in `culture.yaml`:
+
+```yaml
+agents:
+- suffix: reachy-mini-mcp
+  backend: claude
+```
+
+`backend: claude` fixes the runtime prompt file to **`CLAUDE.md`** (this file).
+Together they satisfy the two invariants `steward doctor` verifies:
+**prompt-file-present** (an agent is declared and the matching prompt file is on
+disk) and **backend-consistency** (`claude` ↔ `CLAUDE.md`).
+
+Sign mesh/issue posts as `- reachy-mini-mcp (Claude)` — the `cicd` / `communicate`
+scripts resolve the nick from `culture.yaml` automatically (via
+`_resolve-nick.sh` / `agtag`), so don't hand-author the trailing signature.
+
+## Two distinct prompts (important)
+
+- **This file (`CLAUDE.md`)** is the *dev / mesh* system prompt — guidance for Claude
+  Code working **on** this repository.
+- **`agents/reachy/reachy.system.md`** is the robot's *runtime* personality prompt
+  ("You are a cute robot called Reachy Mini…") loaded into the conversation agent that
+  drives the physical robot.
+
+They are different files for different audiences. Editing one is not editing the other.
+
+## Architecture / Layout
+
+```text
+server.py                 FastMCP server; the operate_robot meta-tool + TOOL_REGISTRY,
+                          loads tool definitions from tools_repository/ at startup
+server_openai.py          OpenAI-compatible server variant
+tts_queue.py              piper-TTS background queue (speaks text passed via "speech")
+tools_repository/         the extensible tool system
+  tools_index.json        index of the 18 robot operations
+  <tool>.json (x18)       per-tool MCP-style definitions
+  scripts/<tool>.py (x18) one Python script per tool (script-based execution)
+  README.md, SCHEMA.md    tool-definition format docs
+dance_moves/              JSON dance sequences
+agents/reachy/            reachy.system.md — the robot runtime prompt (see above)
+requirements.txt          fastmcp, httpx, reachy-mini, mcp, piper-tts, pyaudio
+.claude/skills/           vendored AgentCulture skill kit (cite-don't-import)
+docs/skill-sources.md     skill provenance ledger
+culture.yaml              mesh identity (suffix + backend)
+```
+
+The 18 operations cover state/monitoring (`get_robot_state`, `get_head_state`,
+`get_antennas_state`, `get_power_state`, `get_health_status`), power
+(`turn_on_robot`, `turn_off_robot`), head motion (`move_head`, `reset_head`,
+`nod_head`, `shake_head`, `tilt_head`, `look_at_direction`), antennas
+(`move_antennas`, `reset_antennas`), expression (`express_emotion`,
+`perform_gesture`), and safety (`stop_all_movements`). All tools execute as standalone
+Python scripts — inline code execution was removed (see `INLINE_REMOVAL_SUMMARY.md`).
+
+## Skills
+
+`.claude/skills/` vendors the **canonical guildmaster skill kit** (12 skills,
+cite-don't-import). Provenance and the re-sync procedure live in
+`docs/skill-sources.md`. Three skills (`think`, `spec-to-plan`,
+`assign-to-workforce`) originate in `devague`, and `outsource` originates in
+`convertible` — all re-broadcast via guildmaster.
+
+Tooling prerequisites: **`devex`** (>=0.21) on PATH (the `cicd` skill delegates the
+PR lifecycle to `devex pr`) and **`agtag`** (>=0.1) on PATH (the `communicate` skill
+wraps `agtag issue`); **`convertible`** on PATH is *optional* — only the `outsource`
+skill needs it, and only when invoked.
+
+This repo is a FastMCP server driven by `requirements.txt`, **not** a Python
+package/CLI. Several kit skills assume a `pyproject.toml` / tests / PyPI / SonarCloud
+project that does not exist here yet — `version-bump`, `run-tests`, `sonarclaude`,
+`pypi-maintainer`, and the SonarCloud/PyPI parts of `cicd` are therefore **dormant**
+(vendored for kit completeness and mesh uniformity). The `cicd` PR lifecycle
+(`devex pr` open/read/reply/delta), `communicate`, `outsource`, and the devague
+workflow trio work today.
+
+## Conventions
+
+- The vendored `.claude/skills/` are cited **verbatim** — do not reformat or edit
+  their scripts; re-sync from guildmaster instead (see `docs/skill-sources.md`).
+- PRs go through the `cicd` skill (`devex pr`). Markdownlint config ignores
+  `.claude/skills/**` (vendored, never reformatted).
+- This repo has **no version-bump merge gate and no PyPI deploy** — do not add claims
+  of either to docs until the corresponding scaffolding actually lands.
+
+## Running
+
+```bash
+pip install -r requirements.txt        # see setup.sh / setup.ps1 for full setup
+./setup_piper_model.sh                 # download the piper TTS voice model
+./start.sh                             # start the MCP server (stdio)
+./start_openai_server.sh               # start the OpenAI-compatible variant
+```
+
+`mcp.stdio.example.json` is a sample MCP client config. `start_daemon.sh` /
+`shutdown_daemon.sh` manage the Reachy Mini daemon.
+
+This file describes the repository **as it exists on disk today**. When you edit, keep
+claims grounded in checked-in reality; mark anything aspirational `(planned)` or move
+it under a `## Roadmap` heading (the README tracks the project roadmap).

--- a/culture.yaml
+++ b/culture.yaml
@@ -1,0 +1,3 @@
+agents:
+- suffix: reachy-mini-mcp
+  backend: claude

--- a/docs/skill-sources.md
+++ b/docs/skill-sources.md
@@ -1,0 +1,90 @@
+# Skill upstream sources
+
+reachy-mini-mcp vendors its `.claude/skills/` from **guildmaster** — the
+AgentCulture **skills supplier** after the steward → guildmaster cutover
+(guildmaster 0.5.0, 2026-05-24). `steward` retains the **alignment** role
+(`steward doctor`, the sibling-pattern baseline); only the skills-supplier role
+moved. This file tracks provenance so re-syncs stay deterministic.
+
+Three skills (`think`, `spec-to-plan`, `assign-to-workforce`) originate in
+[`agentculture/devague`](https://github.com/agentculture/devague); one skill
+(`outsource`) originates in
+[`agentculture/convertible`](https://github.com/agentculture/convertible).
+guildmaster only **re-broadcasts** these four. Cite guildmaster's copy; track
+devague / convertible as the true origin.
+
+Every vendored `SKILL.md` carries `type: command`. reachy-mini-mcp declares a
+culture agent (`culture.yaml`, `backend: claude`), and `core.skill_loader`
+silently skips any `SKILL.md` lacking `type:` — so the field is load-bearing,
+even where guildmaster's upstream copy omits it. The field was added to the
+seven skills whose guildmaster copy lacked it (`cicd`, `communicate`,
+`doc-test-alignment`, `pypi-maintainer`, `run-tests`, `sonarclaude`,
+`version-bump`); the other five already carried it upstream.
+
+## Dormant skills
+
+reachy-mini-mcp is a FastMCP server driven by `requirements.txt` — **not** a
+Python package/CLI. Several kit skills assume a `pyproject.toml` / tests / PyPI /
+SonarCloud project that does not exist here yet. They are vendored whole (the
+canonical kit is vendored as a set, not curated) but are **dormant** until that
+scaffolding lands: `version-bump`, `run-tests`, `sonarclaude`, `pypi-maintainer`,
+and the SonarCloud/PyPI parts of `cicd`. The `cicd` PR lifecycle (`devex pr`),
+`communicate`, `outsource`, `agent-config`, and the devague workflow trio work
+today.
+
+| Skill | Upstream | Origin | Notes | Last synced |
+|-------|----------|--------|-------|-------------|
+| `cicd` | `../guildmaster/.claude/skills/cicd/` | guildmaster | CI/CD lane layered on `devex pr`: the 5 thin scripts (`workflow.sh`, `pr-status.sh`, `pr-reply.sh`, `_resolve-nick.sh`, `portability-lint.sh`) delegate lint/open/read/reply/delta to `devex` and add the `status` / `await` SonarCloud-gating extensions. Consumer-identifying prose (`guildmaster` → `reachy-mini-mcp`) adapted in the description + heading; upstream history (`Renamed from pr-review in steward 0.7.0; rebased on devex in 0.12.0`) and env-var literals (`STEWARD_*`) kept verbatim. The PR signature resolves at runtime from `culture.yaml` via `_resolve-nick.sh` (→ `reachy-mini-mcp`). Requires `devex` on PATH. **SonarCloud `status`/`await` extensions are dormant** (no Sonar project yet). | 2026-06-02 (guildmaster 0.9.2, `851732a`) |
+| `communicate` | `../guildmaster/.claude/skills/communicate/` | guildmaster | Cross-repo + mesh communication. Consumer-identifying prose adapted in the description (incl. the `- reachy-mini-mcp (Claude)` signature line). **No hard-coded signature literal in the scripts** — `post-issue.sh` is `agtag`-backed and resolves the signing nick from `culture.yaml`; requires `agtag` (>=0.1) on PATH. The supplier `scripts/templates/` (`skill-update-brief.md`) are kept verbatim — inert for a consumer (they cite guildmaster as upstream). Renamed from `coordinate` in steward 0.8.0; absorbed `gh-issues` in 0.9.1. | 2026-06-02 (guildmaster 0.9.2, `851732a`) |
+| `version-bump` | `../guildmaster/.claude/skills/version-bump/` | guildmaster | Pure-Python, CWD-aware (`scripts/bump.py`). Verbatim except added `type: command`. **Dormant** — bumps `pyproject.toml`, which this repo does not have. | 2026-06-02 (guildmaster 0.9.2, `851732a`) |
+| `agent-config` | `../guildmaster/.claude/skills/agent-config/` | guildmaster (origin steward) | Shows a Culture agent's full config; run `scripts/show.sh` directly (no `guild` binary required). `scripts/show.sh` + `data/backend-fingerprints.yaml` verbatim (already carried `type: command`). | 2026-06-02 (guildmaster 0.9.2, `851732a`) |
+| `doc-test-alignment` | `../guildmaster/.claude/skills/doc-test-alignment/` | guildmaster | **STUB** — `scripts/check.sh` exits not-yet-implemented; the contract lives in SKILL.md. Verbatim except added `type: command`. | 2026-06-02 (guildmaster 0.9.2, `851732a`) |
+| `pypi-maintainer` | `../guildmaster/.claude/skills/pypi-maintainer/` | guildmaster | Switch a package install between PyPI / TestPyPI / local editable (`scripts/switch-source.sh`). Verbatim except added `type: command`. **Dormant** — no PyPI package here. | 2026-06-02 (guildmaster 0.9.2, `851732a`) |
+| `run-tests` | `../guildmaster/.claude/skills/run-tests/` | guildmaster | pytest + xdist + coverage (`scripts/test.sh`). Verbatim except added `type: command`. **Dormant** — no `tests/` / `pyproject.toml` yet. | 2026-06-02 (guildmaster 0.9.2, `851732a`) |
+| `sonarclaude` | `../guildmaster/.claude/skills/sonarclaude/` | guildmaster | SonarCloud API queries (`scripts/sonar.sh`). Verbatim except added `type: command`. **Dormant** — no Sonar project yet. | 2026-06-02 (guildmaster 0.9.2, `851732a`) |
+| `think` | `../guildmaster/.claude/skills/think/` | **devague** (re-broadcast via guildmaster) | idea→spec leg of the devague workflow chain. Verbatim (already carried `type: command`). Origin/broadcast prose left verbatim. | 2026-06-02 (guildmaster 0.9.2, `851732a`) |
+| `spec-to-plan` | `../guildmaster/.claude/skills/spec-to-plan/` | **devague** (re-broadcast via guildmaster) | spec→plan leg of the devague workflow chain. Verbatim (already carried `type: command`). | 2026-06-02 (guildmaster 0.9.2, `851732a`) |
+| `assign-to-workforce` | `../guildmaster/.claude/skills/assign-to-workforce/` | **devague** (re-broadcast via guildmaster) | plan→parallel-implementation leg of the devague workflow chain. Verbatim (already carried `type: command`). | 2026-06-02 (guildmaster 0.9.2, `851732a`) |
+| `outsource` | `../guildmaster/.claude/skills/outsource/` | **convertible** (re-broadcast via guildmaster) | Hand a scoped task to convertible — a *different* engine/mind — via `explore` / `review` / `write`. `explore`/`review` run isolated in a throwaway `git worktree`; `write` refuses a dirty tree. Verbatim (already carried `type: command`; the only upstream divergence is guildmaster's re-broadcast-reframed Provenance paragraph, which we inherit as-is). Optional runtime dep: **`convertible`** on PATH. | 2026-06-02 (guildmaster 0.9.2, `851732a`) |
+
+## Re-sync procedure
+
+```bash
+# Diff against upstream before pulling (example: cicd / communicate):
+for s in cicd communicate; do
+  diff -ru ../guildmaster/.claude/skills/$s .claude/skills/$s
+done
+
+# Pull a skill fresh (remove first so dropped scripts don't linger):
+rm -rf .claude/skills/<skill>
+cp -R ../guildmaster/.claude/skills/<skill> .claude/skills/
+
+# Re-apply the identifier-only adaptations in SKILL.md:
+#   - consumer-identifying prose: `guildmaster` → `reachy-mini-mcp` (NOT where
+#     it cites guildmaster/steward/devague/convertible as the upstream/origin).
+#   - add `type: command` to the frontmatter if guildmaster's copy omits it
+#     (load-bearing for the culture/claude backend's core.skill_loader).
+# No script bodies are edited (cite-don't-import). The communicate signature
+# resolves from culture.yaml via agtag — no literal to patch.
+```
+
+Only `cicd/SKILL.md` and `communicate/SKILL.md` carry consumer-identifying prose;
+the other ten skills are byte-for-byte identical to guildmaster except for the
+`type: command` line added to the seven that lacked it. If a re-sync would lose a
+reachy-mini-mcp adaptation, lift the change upstream into guildmaster first and
+re-vendor.
+
+## Tooling prerequisites
+
+- **`devex`** (>=0.21) on PATH — `cicd` delegates the PR lifecycle to `devex pr`.
+- **`agtag`** (>=0.1) on PATH — `communicate` issue I/O wraps `agtag issue`.
+
+Both ship on PATH in the standard AgentCulture dev setup (installed per the
+devex / agtag READMEs).
+
+- **`convertible`** on PATH — *optional*; only the `outsource` skill needs it,
+  and only when invoked (`uv tool install convertible-cli`). The wrapper exits
+  with a clear install hint if it is absent, so the skill degrades gracefully
+  rather than blocking a clone that never uses it. `outsource` also needs a
+  reachable engine — a local vLLM by default, overridable via `--engine` /
+  `--model` / `--base-url` or `CONVERTIBLE_*` env.

--- a/mcp.stdio.example.json
+++ b/mcp.stdio.example.json
@@ -2,9 +2,9 @@
   "mcpServers": {
     "reachy-mini": {
       "command": "python",
-      "args": ["/home/thor/git/reachy-mini-mcp/server.py"],
+      "args": ["/path/to/reachy-mini-mcp/server.py"],
       "env": {
-        "PYTHONPATH": "/home/thor/git/reachy-mini-mcp:/home/thor/git/reachy-mini-mcp/.venv/lib/python3.12/site-packages"
+        "PYTHONPATH": "/path/to/reachy-mini-mcp:/path/to/reachy-mini-mcp/.venv/lib/python3.12/site-packages"
       }
     }
   }


### PR DESCRIPTION
Closes #10.

Onboards `reachy-mini-mcp` into the AgentCulture mesh: establishes the agent
identity and vendors the 12 canonical guildmaster skills (cite-don't-import).
Done as a **single onboarding PR** — identity and the kit must land together for
`steward doctor` to pass.

## Identity
- **`culture.yaml`** — declares `suffix: reachy-mini-mcp`, `backend: claude`.
- **`CLAUDE.md`** — dev/mesh system prompt describing the FastMCP server, the
  `operate_robot` meta-tool, the `tools_repository` pattern, the vendored skill
  kit, and the distinction between this file and the robot's *runtime* prompt at
  `agents/reachy/reachy.system.md`.

## Vendored skills (`.claude/skills/`, 37 files)
From **guildmaster 0.9.2** (`851732a`): `agent-config`, `assign-to-workforce`,
`cicd`, `communicate`, `doc-test-alignment`, `outsource`, `pypi-maintainer`,
`run-tests`, `sonarclaude`, `spec-to-plan`, `think`, `version-bump`.

Cite-don't-import — script bodies are **byte-for-byte verbatim** (exec bits
preserved). The only adaptations:
- `type: command` added to the 7 SKILL.md that lacked it (load-bearing for
  culture's `core.skill_loader`).
- Consumer-identifying prose re-pointed `guildmaster` → `reachy-mini-mcp` in the
  `cicd`/`communicate` **descriptions only**; all origin/upstream history
  (`steward`, `devague`, `convertible`) kept verbatim.

Three skills (`think`, `spec-to-plan`, `assign-to-workforce`) originate in
`devague`; `outsource` originates in `convertible` — all re-broadcast via
guildmaster. Provenance + re-sync procedure recorded in `docs/skill-sources.md`.

**Dormant skills:** this repo is a FastMCP server (`requirements.txt`), not a
Python package. `version-bump`, `run-tests`, `sonarclaude`, `pypi-maintainer`,
and the PyPI/Sonar parts of `cicd` assume a `pyproject.toml`/tests/PyPI/Sonar
project that doesn't exist here yet — vendored for kit completeness and marked
dormant in the ledger. The `cicd` PR lifecycle, `communicate`, `outsource`, and
the devague trio work today.

## Supporting config
- `.markdownlint-cli2.yaml` (ignores `.claude/skills/**` — vendored verbatim).
- `.claude/skills.local.yaml.example`.
- `.gitignore`: ignore `.teken/`, `.devex/`, `skills.local.yaml`,
  `.claude/settings.local.json`.

## Out-of-band fix
`mcp.stdio.example.json` hard-coded `/home/thor/...` paths, which failed
`steward doctor`'s portability check. Replaced with a `/path/to/...` placeholder
so the onboarding gate passes (and the example works for anyone cloning).

## Verification
- `steward doctor . --scope self` → **doctor clean (4 checks)**, exit 0.
- `guild whoami` → `agent: reachy-mini-mcp (backend: claude)`.
- `_resolve-nick.sh` → `reachy-mini-mcp`.
- `diff -ru` vs guildmaster → only the intended `type:`/prose edits.
- 37 vendored files, all scripts mode `100755`.
- `markdownlint-cli2` on the onboarding files → 0 errors; `.claude/skills/**`
  correctly ignored. (Pre-existing lint findings in `tools_repository/*.md` are
  unrelated to onboarding and left untouched.)

- reachy-mini-mcp (Claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)