### PR TITLE
test: 95% coverage gate + coverage.xml pipeline + SonarCloud wiring

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,8 +19,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    # Promote SONAR_TOKEN to job env so the SonarCloud step can gate on
+    # `env.SONAR_TOKEN != ''` (secrets.* isn't allowed in `if:`). Token-less
+    # repos and fork PRs (no injected secret) skip the scan and stay green.
+    env:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          # Sonar needs full git history for "new code" blame attribution.
+          fetch-depth: 0
 
       - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
 
@@ -31,9 +39,17 @@ jobs:
       # pygobject → pycairo (needs system cairo to build; not on the runner).
       - run: uv venv
 
-      - run: uv pip install -e . pytest pytest-xdist
+      - run: uv pip install -e . pytest pytest-xdist pytest-cov
 
-      - run: uv run --no-project pytest -n auto -v
+      # Emit coverage.xml (repo-relative paths via coverage's relative_files) for
+      # SonarCloud; --cov enforces the fail_under=95 gate in pyproject.toml.
+      - run: uv run --no-project pytest -n auto --cov=reachy_mini_mcp --cov-report=xml:coverage.xml --cov-report=term -v
+
+      - name: SonarCloud Scan
+        if: env.SONAR_TOKEN != ''
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
+        env:
+          SONAR_HOST_URL: https://sonarcloud.io
 
   test-publish:
     # Skip on fork PRs — no OIDC/environment context is available there, so

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,12 +7,16 @@ on:
       - "pyproject.toml"
       - "reachy_mini_mcp/**"
       - "tests/**"
+      - "sonar-project.properties"
+      - ".github/workflows/publish.yml"
   pull_request:
     branches: [main]
     paths:
       - "pyproject.toml"
       - "reachy_mini_mcp/**"
       - "tests/**"
+      - "sonar-project.properties"
+      - ".github/workflows/publish.yml"
 
 jobs:
   test:

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ Thumbs.db
 # Testing
 .pytest_cache/
 .coverage
+coverage.xml
 htmlcov/
 
 # MCP specific

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 - Coverage gate: pyproject.toml [tool.coverage.report] now sets fail_under = 95; CLI-manager coverage raised from 84% to ~99%.
 
+### Fixed
+
+- publish.yml `paths:` filter now also triggers on `sonar-project.properties` and the workflow file itself, so Sonar/coverage-config changes can't silently skip CI (Qodo review, PR #13).
+
 ## [0.1.0] - 2026-06-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.0] - 2026-06-03
+
+### Added
+
+- Test pipeline now generates coverage.xml and runs a SonarCloud scan in CI (publish.yml test job), guarded by SONAR_TOKEN so token-less and fork PRs stay green.
+- sonar-project.properties (projectKey agentculture_reachy_mini_mcp) wiring SonarCloud coverage decoration; robot runtime is coverage-excluded but kept indexed for static analysis.
+- Manager-CLI unit tests for serve lazy-import, doctor checks, overview render, dispatch/error routing, _meta/_output helpers, client-config edge cases, and the __main__ entrypoint.
+
+### Changed
+
+- Coverage gate: pyproject.toml [tool.coverage.report] now sets fail_under = 95; CLI-manager coverage raised from 84% to ~99%.
+
 ## [0.1.0] - 2026-06-02
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,10 @@ reachy-mini-mcp serve --openai    # or: python -m reachy_mini_mcp.server_openai
 # Tests (manager CLI only — no robot stack/daemon needed). Avoid `uv sync`/`uv run
 # pytest`: the universal resolve pulls the [server] extra → reachy-mini → pycairo,
 # which needs system cairo to build. Install just the manager + pytest instead:
-uv pip install -e . pytest pytest-xdist   # `uv venv` first if you have no venv
+uv pip install -e . pytest pytest-xdist pytest-cov   # `uv venv` first if you have no venv
+# Plain run, or with coverage (CI uses the --cov form; fail_under=95 gate applies):
 uv run --no-project pytest -n auto -v
+uv run --no-project pytest -n auto --cov=reachy_mini_mcp --cov-report=xml:coverage.xml --cov-report=term -v
 
 # Piper TTS voice model download helper
 ./setup_piper_model.sh
@@ -172,10 +174,17 @@ needs it, and only when invoked.
 As of the `0.1.0` packaging work the repo now has a `pyproject.toml`, a `tests/`
 suite, and a PyPI/TestPyPI publish workflow, so **`version-bump`, `run-tests`, and
 `pypi-maintainer` are now live** (the dist name is `reachy-mini-mcp`; CI publishes
-via OIDC Trusted Publishing in `.github/workflows/publish.yml`). Still dormant:
-`sonarclaude` and the SonarCloud parts of `cicd` (no SonarCloud project wired).
-The `cicd` PR lifecycle (`devex pr` open/read/reply/delta), `communicate`,
-`outsource`, and the devague workflow trio work today.
+via OIDC Trusted Publishing in `.github/workflows/publish.yml`). As of `0.2.0`, the
+`publish.yml` `test` job also generates `coverage.xml` and runs a **SonarCloud**
+scan (`sonar-project.properties`, projectKey `agentculture_reachy_mini_mcp`; CLI
+coverage is gated at `fail_under = 95`). The scan step is guarded by
+`if: env.SONAR_TOKEN != ''`, so it stays inert — and `sonarclaude` / the SonarCloud
+parts of `cicd` return no data — until the external SonarCloud project and the
+`SONAR_TOKEN` repo secret are provisioned; once they are, both go live with no code
+change. The robot runtime is coverage-excluded (it needs a live daemon/hardware)
+but kept indexed for static analysis. The `cicd` PR lifecycle (`devex pr`
+open/read/reply/delta), `communicate`, `outsource`, and the devague workflow trio
+work today.
 
 The vendored `.claude/skills/` are cited **verbatim** — do not reformat or edit their
 scripts; re-sync from guildmaster instead (see `docs/skill-sources.md`). The

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Reachy Mini MCP Server
 
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=agentculture_reachy_mini_mcp&metric=coverage)](https://sonarcloud.io/summary/new_code?id=agentculture_reachy_mini_mcp)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=agentculture_reachy_mini_mcp&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=agentculture_reachy_mini_mcp)
+
+<!-- Badges activate once the SonarCloud project `agentculture_reachy_mini_mcp` and
+the `SONAR_TOKEN` repo secret are provisioned; see CLAUDE.md. -->
+
 A Model Context Protocol (MCP) server for controlling the [Reachy Mini](https://github.com/pollen-robotics/reachy_mini) robot using [FastMCP](https://github.com/jlowin/fastmcp).
 
 > [!NOTE]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "reachy-mini-mcp"
-version = "0.1.0"
+version = "0.2.0"
 description = "MCP server + manager CLI for the Reachy Mini robot."
 readme = "README.md"
 license = "MIT"
@@ -84,6 +84,7 @@ relative_files = true
 
 [tool.coverage.report]
 show_missing = true
+fail_under = 95
 exclude_lines = [
     "pragma: no cover",
     "if __name__ == .__main__.",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,27 @@
+# SonarCloud project identity. The project must be registered on SonarCloud
+# under the `agentculture` org with this exact key, and a SONAR_TOKEN secret
+# added to the repo, before coverage decoration appears (see CLAUDE.md). Until
+# then the CI scan step is skipped (`if: env.SONAR_TOKEN != ''`).
+sonar.projectKey=agentculture_reachy_mini_mcp
+sonar.organization=agentculture
+
+# Source layout — the package lives at the top level (no src/ wrapper).
+sonar.sources=reachy_mini_mcp
+sonar.tests=tests
+
+# Coverage report produced in CI by `pytest --cov-report=xml:coverage.xml`
+# (see .github/workflows/publish.yml). Path is relative to the repo root.
+sonar.python.coverage.reportPaths=coverage.xml
+sonar.python.version=3.10,3.11,3.12
+
+# General analysis noise.
+sonar.exclusions=**/__pycache__/**,**/.venv/**,uv.lock
+
+# Robot runtime needs a live daemon + hardware (and the heavy [server]/[tts]
+# extras CI can't build), so it's omitted from coverage in pyproject.toml. Mirror
+# that here as a COVERAGE exclusion only — these files stay indexed for bugs /
+# code smells / security hotspots, they just don't drag the coverage % to 0.
+sonar.coverage.exclusions=reachy_mini_mcp/server.py,reachy_mini_mcp/server_openai.py,reachy_mini_mcp/tts_queue.py,reachy_mini_mcp/tools_repository/**
+
+# Block CI on a failing quality gate once the scan is active.
+sonar.qualitygate.wait=true

--- a/tests/test_cli_dispatch.py
+++ b/tests/test_cli_dispatch.py
@@ -1,0 +1,75 @@
+"""Top-level dispatch: argparse errors, ReachyError, and last-resort wrapping
+all route through the structured ``emit_error`` path with the right exit codes."""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+
+import pytest
+
+from reachy_mini_mcp.cli import main
+from reachy_mini_mcp.cli._commands import show
+from reachy_mini_mcp.cli._errors import EXIT_USER_ERROR
+
+
+def test_unknown_subcommand_routes_through_emit_error(capsys):
+    with pytest.raises(SystemExit) as exc:
+        main(["bogus-subcommand"])
+    assert exc.value.code == EXIT_USER_ERROR
+    err = capsys.readouterr().err
+    assert "error:" in err
+    assert "hint:" in err
+
+
+def test_unknown_flag_routes_through_emit_error(capsys):
+    with pytest.raises(SystemExit) as exc:
+        main(["show", "--no-such-flag"])
+    assert exc.value.code == EXIT_USER_ERROR
+    assert "error:" in capsys.readouterr().err
+
+
+def test_dispatch_catches_reachy_error(tmp_path, capsys):
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text('{"mcpServers": {"reachy-mini": {"command": "old"}}}', encoding="utf-8")
+    # A conflicting entry without --force makes merge_entry raise ReachyError,
+    # which _dispatch must turn into exit code 1 (not a traceback).
+    assert main(["install", "--path", str(cfg)]) == EXIT_USER_ERROR
+    assert "already exists with different settings" in capsys.readouterr().err
+
+
+def test_dispatch_wraps_unexpected_exception(monkeypatch, capsys):
+    def boom(_args):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(show, "_handle", boom)
+    assert main(["show"]) == EXIT_USER_ERROR
+    err = capsys.readouterr().err
+    assert "unexpected: RuntimeError" in err
+    assert "file a bug" in err
+
+
+def test_dispatch_keyboard_interrupt_returns_130(monkeypatch):
+    def boom(_args):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(show, "_handle", boom)
+    assert main(["show"]) == 130
+
+
+def test_main_module_imports_cleanly():
+    # Importing the module (name != "__main__") runs its top-level imports under
+    # coverage; the `sys.exit(main())` guard is excluded by coverage config.
+    mod = importlib.import_module("reachy_mini_mcp.__main__")
+    assert hasattr(mod, "main")
+
+
+def test_python_m_entrypoint_runs():
+    result = subprocess.run(
+        [sys.executable, "-m", "reachy_mini_mcp", "show"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "mcpServers" in result.stdout

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -52,6 +52,13 @@ def test_doctor_passes_hard_checks(monkeypatch):
     assert main(["doctor"]) == 0
 
 
+def test_show_entry_only(capsys):
+    assert main(["show", "--entry-only"]) == 0
+    out = capsys.readouterr().out
+    assert '"command"' in out
+    assert '"mcpServers"' not in out
+
+
 def test_install_uninstall_roundtrip(tmp_path, capsys):
     cfg = tmp_path / "mcp.json"
     assert main(["install", "--path", str(cfg)]) == 0
@@ -59,6 +66,36 @@ def test_install_uninstall_roundtrip(tmp_path, capsys):
     assert "reachy-mini" in cfg.read_text()
     assert main(["uninstall", "--path", str(cfg)]) == 0
     assert "reachy-mini" not in cfg.read_text()
+
+
+def test_install_dry_run_does_not_write(tmp_path, capsys):
+    cfg = tmp_path / "mcp.json"
+    assert main(["install", "--path", str(cfg), "--dry-run"]) == 0
+    assert '"mcpServers"' in capsys.readouterr().out
+    assert not cfg.exists()
+
+
+def test_install_idempotent_reports_no_change(tmp_path, capsys):
+    cfg = tmp_path / "mcp.json"
+    assert main(["install", "--path", str(cfg)]) == 0
+    capsys.readouterr()
+    assert main(["install", "--path", str(cfg)]) == 0
+    assert "already registered" in capsys.readouterr().err
+
+
+def test_uninstall_dry_run_keeps_entry(tmp_path, capsys):
+    cfg = tmp_path / "mcp.json"
+    assert main(["install", "--path", str(cfg)]) == 0
+    capsys.readouterr()
+    assert main(["uninstall", "--path", str(cfg), "--dry-run"]) == 0
+    assert "reachy-mini" in cfg.read_text()  # dry-run did not remove it
+
+
+def test_uninstall_nothing_to_do(tmp_path, capsys):
+    cfg = tmp_path / "mcp.json"
+    cfg.write_text('{"mcpServers": {}}', encoding="utf-8")
+    assert main(["uninstall", "--path", str(cfg)]) == 0
+    assert "nothing to do" in capsys.readouterr().err
 
 
 def test_manager_does_not_import_robot_stack():

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import json
+import sys
 
 import pytest
 
@@ -82,3 +82,74 @@ def test_resolve_claude_code_scopes(tmp_path, monkeypatch):
     assert project.path == tmp_path / ".mcp.json"
     user = _clients.resolve_target(client="claude-code", scope="user")
     assert user.path.name == ".claude.json"
+
+
+def test_claude_desktop_path_darwin(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    target = _clients.resolve_target(client="claude-desktop")
+    assert target.path.as_posix().endswith(
+        "Library/Application Support/Claude/claude_desktop_config.json"
+    )
+
+
+def test_claude_desktop_path_windows_with_appdata(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    target = _clients.resolve_target(client="claude-desktop")
+    assert target.path == tmp_path / "Claude" / "claude_desktop_config.json"
+
+
+def test_claude_desktop_path_windows_without_appdata(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.delenv("APPDATA", raising=False)
+    target = _clients.resolve_target(client="claude-desktop")
+    assert "AppData" in target.path.parts
+    assert "Roaming" in target.path.parts
+
+
+def test_resolve_target_unknown_scope():
+    with pytest.raises(ReachyError):
+        _clients.resolve_target(client="claude-code", scope="bogus")
+
+
+def test_load_config_oserror_on_directory(tmp_path):
+    # Reading a directory as text raises OSError → ReachyError, not a traceback.
+    d = tmp_path / "is_a_dir"
+    d.mkdir()
+    with pytest.raises(ReachyError):
+        _clients.load_config(d)
+
+
+def test_load_config_empty_file_returns_empty(tmp_path):
+    p = tmp_path / "empty.json"
+    p.write_text("   \n", encoding="utf-8")
+    assert _clients.load_config(p) == {}
+
+
+def test_load_config_rejects_non_object(tmp_path):
+    p = tmp_path / "array.json"
+    p.write_text("[1, 2, 3]", encoding="utf-8")
+    with pytest.raises(ReachyError):
+        _clients.load_config(p)
+
+
+def test_merge_entry_rejects_non_object_servers():
+    with pytest.raises(ReachyError):
+        _clients.merge_entry({"mcpServers": "not-an-object"}, name="reachy-mini", entry=ENTRY)
+
+
+def test_is_installed_swallows_bad_json(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    assert _clients.is_installed(bad, name="reachy-mini") is False
+
+
+def test_write_config_oserror_becomes_reachy_error(tmp_path, monkeypatch):
+    # Force the atomic replace to fail; write_config must surface a ReachyError
+    # (and clean up the temp file) rather than leak the OSError.
+    def boom(*a, **k):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(_clients.os, "replace", boom)
+    with pytest.raises(ReachyError):
+        _clients.write_config(tmp_path / "cfg.json", {"mcpServers": {}})

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,106 @@
+"""``doctor`` health-check branches: each Check helper and the text/JSON output.
+
+Daemon probing is patched at the command module's binding (``doctor`` imports
+``daemon_status`` by name, so the effective target is
+``reachy_mini_mcp.cli._commands.doctor.daemon_status``) — never the network.
+"""
+
+from __future__ import annotations
+
+import json
+
+from reachy_mini_mcp.cli import main
+from reachy_mini_mcp.cli._commands import doctor
+
+
+def _offline(monkeypatch):
+    monkeypatch.setattr(doctor, "daemon_status", lambda *a, **k: (False, "stubbed offline"))
+
+
+def test_tools_check_missing_index_is_hard_fail(tmp_path, monkeypatch):
+    monkeypatch.setattr(doctor, "tools_dir", lambda: tmp_path)
+    check = doctor._tools_check()
+    assert check.status == doctor._FAIL
+    assert check.hard is True
+    assert "tools_index.json missing" in check.detail
+
+
+def test_doctor_hard_fail_returns_env_error(tmp_path, monkeypatch, capsys):
+    _offline(monkeypatch)
+    monkeypatch.setattr(doctor, "tools_dir", lambda: tmp_path)
+    assert main(["doctor"]) == 2  # EXIT_ENV_ERROR
+    assert "FAILED" in capsys.readouterr().out
+
+
+def test_available_swallows_value_error(monkeypatch):
+    def boom(_name):
+        raise ValueError("dotted name with leading dot")
+
+    monkeypatch.setattr(doctor.importlib.util, "find_spec", boom)
+    assert doctor._available("..bad") is False
+
+
+def test_import_check_all_present(monkeypatch):
+    monkeypatch.setattr(doctor, "_available", lambda _m: True)
+    check = doctor._import_check("server-extra", ["fastmcp", "httpx"], "server")
+    assert check.status == doctor._OK
+    assert check.detail == "installed"
+
+
+def test_import_check_reports_missing(monkeypatch):
+    monkeypatch.setattr(doctor, "_available", lambda _m: False)
+    check = doctor._import_check("server-extra", ["fastmcp"], "server")
+    assert check.status == doctor._WARN
+    assert "fastmcp" in check.detail
+
+
+def test_binaries_check_all_present(monkeypatch):
+    monkeypatch.setattr(doctor.shutil, "which", lambda b: f"/usr/bin/{b}")
+    check = doctor._binaries_check()
+    assert check.status == doctor._OK
+    assert "piper and aplay" in check.detail
+
+
+def test_env_check_reports_set_vars(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)  # no .env here, so only env vars contribute
+    monkeypatch.setenv("REACHY_BASE_URL", "http://x:1")
+    detail = doctor._env_check().detail
+    assert detail.startswith("set: ")
+    assert "REACHY_BASE_URL" in detail
+
+
+def test_env_check_reports_dotenv(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("X=1\n", encoding="utf-8")
+    for k in ("REACHY_BASE_URL", "PIPER_MODEL", "AUDIO_DEVICE"):
+        monkeypatch.delenv(k, raising=False)
+    assert ".env present" in doctor._env_check().detail
+
+
+def test_env_check_defaults_when_nothing_set(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    for k in ("REACHY_BASE_URL", "PIPER_MODEL", "AUDIO_DEVICE"):
+        monkeypatch.delenv(k, raising=False)
+    assert "no robot env vars set" in doctor._env_check().detail
+
+
+def test_install_check_reports_installed(monkeypatch):
+    monkeypatch.setattr(doctor._clients, "is_installed", lambda path, *, name: True)
+    assert doctor._install_check().status == doctor._OK
+
+
+def test_install_check_reports_none(monkeypatch):
+    monkeypatch.setattr(doctor._clients, "is_installed", lambda path, *, name: False)
+    check = doctor._install_check()
+    assert check.status == doctor._WARN
+    assert "not registered" in check.detail
+
+
+def test_doctor_json_output(monkeypatch, capsys):
+    _offline(monkeypatch)
+    assert main(["doctor", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert set(payload) == {"ok", "checks"}
+    assert payload["ok"] is True
+    assert isinstance(payload["checks"], list)
+    assert {"name", "status", "detail", "hard"} <= set(payload["checks"][0])

--- a/tests/test_mcp_entry.py
+++ b/tests/test_mcp_entry.py
@@ -36,3 +36,18 @@ def test_entry_only_helper():
 def test_base_url_from_env(monkeypatch):
     monkeypatch.setenv("REACHY_BASE_URL", "http://daemon:1234")
     assert _mcp.build_env()["REACHY_BASE_URL"] == "http://daemon:1234"
+
+
+def test_build_env_folds_in_optional_tts_vars(monkeypatch):
+    monkeypatch.setenv("PIPER_MODEL", "/models/voice")
+    monkeypatch.setenv("AUDIO_DEVICE", "hw:1,0")
+    env = _mcp.build_env()
+    assert env["PIPER_MODEL"] == "/models/voice"
+    assert env["AUDIO_DEVICE"] == "hw:1,0"
+
+
+def test_resolve_command_installed_uses_console_script(monkeypatch):
+    monkeypatch.setattr(_mcp.shutil, "which", lambda _name: "/usr/local/bin/reachy-mini-mcp")
+    command, args = _mcp.resolve_command()
+    assert command == "/usr/local/bin/reachy-mini-mcp"
+    assert args == ["serve"]

--- a/tests/test_output_meta.py
+++ b/tests/test_output_meta.py
@@ -1,0 +1,84 @@
+"""Shared helpers: ``_output.emit_error`` formatting and ``_meta`` probes
+(``count_tools`` edge cases and ``daemon_status`` for each urllib outcome)."""
+
+from __future__ import annotations
+
+import io
+import urllib.error
+
+from reachy_mini_mcp.cli import _meta
+from reachy_mini_mcp.cli._errors import ReachyError
+from reachy_mini_mcp.cli._output import emit_error
+
+
+def test_emit_error_writes_message_and_hint():
+    buf = io.StringIO()
+    emit_error(ReachyError(code=1, message="boom", remediation="do x"), stream=buf)
+    assert buf.getvalue() == "error: boom\nhint: do x\n"
+
+
+def test_emit_error_omits_empty_hint():
+    buf = io.StringIO()
+    emit_error(ReachyError(code=1, message="boom"), stream=buf)
+    assert buf.getvalue() == "error: boom\n"
+
+
+def test_reachy_error_to_dict_round_trips_fields():
+    err = ReachyError(code=2, message="oops", remediation="retry")
+    assert err.to_dict() == {"code": 2, "message": "oops", "remediation": "retry"}
+
+
+def test_count_tools_missing_index(tmp_path, monkeypatch):
+    monkeypatch.setattr(_meta, "tools_dir", lambda: tmp_path)
+    assert _meta.count_tools() == (0, 0)
+
+
+def test_count_tools_bad_shape(tmp_path, monkeypatch):
+    (tmp_path / "tools_index.json").write_text('{"tools": "not-a-list"}', encoding="utf-8")
+    monkeypatch.setattr(_meta, "tools_dir", lambda: tmp_path)
+    assert _meta.count_tools() == (0, 0)
+
+
+def test_count_tools_counts_enabled(tmp_path, monkeypatch):
+    (tmp_path / "tools_index.json").write_text(
+        '{"tools": [{"enabled": true}, {"enabled": false}, {}]}', encoding="utf-8"
+    )
+    monkeypatch.setattr(_meta, "tools_dir", lambda: tmp_path)
+    assert _meta.count_tools() == (2, 3)  # {} defaults to enabled=True
+
+
+class _FakeResp:
+    status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def test_daemon_status_reachable(monkeypatch):
+    monkeypatch.setattr(_meta.urllib.request, "urlopen", lambda *a, **k: _FakeResp())
+    reachable, detail = _meta.daemon_status("http://localhost:8000")
+    assert reachable is True
+    assert detail == "HTTP 200"
+
+
+def test_daemon_status_http_error_is_still_reachable(monkeypatch):
+    def boom(*a, **k):
+        raise urllib.error.HTTPError("http://x", 503, "unavailable", {}, None)
+
+    monkeypatch.setattr(_meta.urllib.request, "urlopen", boom)
+    reachable, detail = _meta.daemon_status("http://localhost:8000")
+    assert reachable is True
+    assert detail == "HTTP 503"
+
+
+def test_daemon_status_connection_failure_is_unreachable(monkeypatch):
+    def boom(*a, **k):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(_meta.urllib.request, "urlopen", boom)
+    reachable, detail = _meta.daemon_status("http://localhost:8000")
+    assert reachable is False
+    assert "connection refused" in detail

--- a/tests/test_overview_render.py
+++ b/tests/test_overview_render.py
@@ -1,0 +1,36 @@
+"""``overview`` render branches: the "Installed" list and the JSON shape."""
+
+from __future__ import annotations
+
+import json
+
+from reachy_mini_mcp.cli import main
+from reachy_mini_mcp.cli._commands import overview
+
+
+def _offline(monkeypatch):
+    monkeypatch.setattr(overview, "daemon_status", lambda *a, **k: (False, "stubbed offline"))
+
+
+def test_overview_lists_installed_clients(monkeypatch, capsys):
+    _offline(monkeypatch)
+    monkeypatch.setattr(overview._clients, "is_installed", lambda path, *, name: True)
+    assert main(["overview"]) == 0
+    out = capsys.readouterr().out
+    assert "Installed   :" in out
+    assert "- claude-code (project):" in out
+
+
+def test_overview_json_output(monkeypatch, capsys):
+    _offline(monkeypatch)
+    assert main(["overview", "--json"]) == 0
+    data = json.loads(capsys.readouterr().out)
+    assert set(data) == {
+        "version",
+        "server_name",
+        "launch",
+        "tools",
+        "daemon",
+        "installed_in",
+    }
+    assert data["daemon"]["reachable"] is False

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1,0 +1,49 @@
+"""``serve`` lazily imports the robot stack — cover both the missing-stack
+error path and the success path without needing the real server installed."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import types
+from unittest import mock
+
+from reachy_mini_mcp.cli import main
+from reachy_mini_mcp.cli._commands import serve
+from reachy_mini_mcp.cli._errors import EXIT_ENV_ERROR
+
+
+def _fake_server_module(name: str) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    mod.main = mock.Mock(name=f"{name}.main")
+    return mod
+
+
+def test_serve_import_error_raises_env_error(monkeypatch, capsys):
+    # A None entry in sys.modules makes `from reachy_mini_mcp.server import main`
+    # raise ImportError — the same outcome as the [server] extra being absent.
+    monkeypatch.setitem(sys.modules, "reachy_mini_mcp.server", None)
+    assert main(["serve"]) == EXIT_ENV_ERROR
+    err = capsys.readouterr().err
+    assert "the server stack is not installed" in err
+    assert "reachy-mini-mcp[server]" in err
+
+
+def test_serve_openai_import_error_raises_env_error(monkeypatch, capsys):
+    monkeypatch.setitem(sys.modules, "reachy_mini_mcp.server_openai", None)
+    assert main(["serve", "--openai"]) == EXIT_ENV_ERROR
+    assert "the server stack is not installed" in capsys.readouterr().err
+
+
+def test_serve_success_path_invokes_server_main(monkeypatch):
+    fake = _fake_server_module("reachy_mini_mcp.server")
+    monkeypatch.setitem(sys.modules, "reachy_mini_mcp.server", fake)
+    assert serve._handle(argparse.Namespace(openai=False)) == 0
+    fake.main.assert_called_once_with()
+
+
+def test_serve_openai_success_path_invokes_server_main(monkeypatch):
+    fake = _fake_server_module("reachy_mini_mcp.server_openai")
+    monkeypatch.setitem(sys.modules, "reachy_mini_mcp.server_openai", fake)
+    assert serve._handle(argparse.Namespace(openai=True)) == 0
+    fake.main.assert_called_once_with()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,23 @@
+"""The package version falls back to a dev marker when the distribution
+metadata is absent (a source tree that was never installed)."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata as md
+
+import reachy_mini_mcp
+
+
+def test_version_falls_back_when_not_installed(monkeypatch):
+    def not_found(name):
+        raise md.PackageNotFoundError(name)
+
+    monkeypatch.setattr(md, "version", not_found)
+    try:
+        reloaded = importlib.reload(reachy_mini_mcp)
+        assert reloaded.__version__ == "0.0.0+dev"
+    finally:
+        # Restore the real, installed version for any later tests.
+        monkeypatch.undo()
+        importlib.reload(reachy_mini_mcp)


### PR DESCRIPTION
## Summary

Gets the repo to a real **95%+ coverage gate**, makes CI emit **`coverage.xml`**, and wires **SonarCloud** to display coverage — mirroring the sibling `colleague` repo's pattern.

- CLI-manager coverage raised **84% → ~99.6%** (75 tests, `fail_under = 95` enforced in CI).
- `publish.yml` `test` job now produces `coverage.xml` and runs a SonarCloud scan.
- `sonar-project.properties` added (projectKey `agentculture_reachy_mini_mcp`).

Scope is the **manager CLI only**, per the repo's design: the robot runtime (`server.py`, `server_openai.py`, `tts_queue.py`, `tools_repository/*`) needs a live daemon + hardware and CI can't build the `[server]` extra (reachy-mini → pycairo), so it stays omitted from coverage and `coverage`-excluded in Sonar (but still indexed for bugs/smells/hotspots).

## What changed

**Tests** (all monkeypatch-based, no daemon/hardware) — closed the gaps in `serve` lazy-import, `doctor` checks + `--json`, `overview` render/installed branch, top-level dispatch (argparse errors, `ReachyError`, unexpected-exception wrap, `KeyboardInterrupt`), `_meta`/`_output` helpers, `_clients` platform + error branches, the `__main__` entrypoint, and the version fallback. New: `test_serve.py`, `test_doctor.py`, `test_overview_render.py`, `test_cli_dispatch.py`, `test_output_meta.py`, `test_version.py`; extended `test_clients.py`, `test_mcp_entry.py`, `test_cli_smoke.py`.

**Pipeline / Sonar**

- `publish.yml` `test` job: install `pytest-cov`; run `pytest --cov=reachy_mini_mcp --cov-report=xml:coverage.xml --cov-report=term`; `fetch-depth: 0`; promote `SONAR_TOKEN` to job env; add a `SonarCloud Scan` step guarded by `if: env.SONAR_TOKEN != ''` (pinned `sonarqube-scan-action@v6`). Keeps the deliberate `uv pip install` (no `uv sync`, which would hit the pycairo build).
- `pyproject.toml`: `[tool.coverage.report] fail_under = 95` (existing `relative_files = true` keeps `coverage.xml` paths repo-relative for Sonar matching).
- `sonar-project.properties`: sources/tests/coverage path, `sonar.coverage.exclusions` for the robot runtime, `sonar.qualitygate.wait=true`.
- `.gitignore` adds `coverage.xml`; README gets coverage + quality-gate badges; `CLAUDE.md` Skills/Commands docs updated; version bumped `0.1.0 → 0.2.0` with a CHANGELOG entry.

## Manual external steps (CI stays green until then)

The scan step is skipped while `SONAR_TOKEN` is empty, so this is mergeable now. To activate Sonar:

1. Create the SonarCloud project `agentculture_reachy_mini_mcp` under the `agentculture` org and **disable Automatic Analysis** (CI-based scan is used).
2. Add the `SONAR_TOKEN` repo secret.

Once both exist the scan activates with no further code change (note `sonar.qualitygate.wait=true` then gates the job).

## Verification

`uv run --no-project pytest -n auto --cov=reachy_mini_mcp --cov-report=term-missing` → **75 passed, 99.60%**, `Required test coverage of 95.0% reached`. `coverage.xml` confirmed with `<source>reachy_mini_mcp</source>` + package-relative filenames (matches Sonar's indexed sources).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- reachy-mini-mcp (Claude)
