### PR TITLE
fix(ci): correct SonarCloud projectKey to hyphenated agentculture_reachy-mini-mcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,18 @@ All notable changes to this project are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.1] - 2026-06-03
+
+### Fixed
+
+- Corrected the SonarCloud projectKey to the hyphenated agentculture_reachy-mini-mcp (matching the GitHub-integration project). The underscored key auto-provisioned a separate project whose main branch defaulted to master, so push-to-main analysis failed with Project not found and blocked the publish job. Updated sonar-project.properties, the README badges, and CLAUDE.md.
+
 ## [0.2.0] - 2026-06-03
 
 ### Added
 
 - Test pipeline now generates coverage.xml and runs a SonarCloud scan in CI (publish.yml test job), guarded by SONAR_TOKEN so token-less and fork PRs stay green.
-- sonar-project.properties (projectKey agentculture_reachy_mini_mcp) wiring SonarCloud coverage decoration; robot runtime is coverage-excluded but kept indexed for static analysis.
+- sonar-project.properties (projectKey agentculture_reachy-mini-mcp) wiring SonarCloud coverage decoration; robot runtime is coverage-excluded but kept indexed for static analysis.
 - Manager-CLI unit tests for serve lazy-import, doctor checks, overview render, dispatch/error routing, _meta/_output helpers, client-config edge cases, and the __main__ entrypoint.
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,7 +176,7 @@ suite, and a PyPI/TestPyPI publish workflow, so **`version-bump`, `run-tests`, a
 `pypi-maintainer` are now live** (the dist name is `reachy-mini-mcp`; CI publishes
 via OIDC Trusted Publishing in `.github/workflows/publish.yml`). As of `0.2.0`, the
 `publish.yml` `test` job also generates `coverage.xml` and runs a **SonarCloud**
-scan (`sonar-project.properties`, projectKey `agentculture_reachy_mini_mcp`; CLI
+scan (`sonar-project.properties`, projectKey `agentculture_reachy-mini-mcp`; CLI
 coverage is gated at `fail_under = 95`). The scan step is guarded by
 `if: env.SONAR_TOKEN != ''`, so it stays inert — and `sonarclaude` / the SonarCloud
 parts of `cicd` return no data — until the external SonarCloud project and the

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Reachy Mini MCP Server
 
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=agentculture_reachy_mini_mcp&metric=coverage)](https://sonarcloud.io/summary/new_code?id=agentculture_reachy_mini_mcp)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=agentculture_reachy_mini_mcp&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=agentculture_reachy_mini_mcp)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=agentculture_reachy-mini-mcp&metric=coverage)](https://sonarcloud.io/summary/new_code?id=agentculture_reachy-mini-mcp)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=agentculture_reachy-mini-mcp&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=agentculture_reachy-mini-mcp)
 
-<!-- Badges activate once the SonarCloud project `agentculture_reachy_mini_mcp` and
+<!-- Badges activate once the SonarCloud project `agentculture_reachy-mini-mcp` and
 the `SONAR_TOKEN` repo secret are provisioned; see CLAUDE.md. -->
 
 A Model Context Protocol (MCP) server for controlling the [Reachy Mini](https://github.com/pollen-robotics/reachy_mini) robot using [FastMCP](https://github.com/jlowin/fastmcp).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "reachy-mini-mcp"
-version = "0.2.0"
+version = "0.2.1"
 description = "MCP server + manager CLI for the Reachy Mini robot."
 readme = "README.md"
 license = "MIT"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@
 # under the `agentculture` org with this exact key, and a SONAR_TOKEN secret
 # added to the repo, before coverage decoration appears (see CLAUDE.md). Until
 # then the CI scan step is skipped (`if: env.SONAR_TOKEN != ''`).
-sonar.projectKey=agentculture_reachy_mini_mcp
+sonar.projectKey=agentculture_reachy-mini-mcp
 sonar.organization=agentculture
 
 # Source layout — the package lives at the top level (no src/ wrapper).


### PR DESCRIPTION
## Summary

Fixes the SonarCloud failure on `main` introduced by #13: the `projectKey` was the **underscored** `agentculture_reachy_mini_mcp`, but the real GitHub-integration project is the **hyphenated** `agentculture_reachy-mini-mcp`.

## Root cause

The underscored key didn't match the existing project, so on PR #13 SonarCloud **auto-provisioned a separate project** `agentculture_reachy_mini_mcp` — the PR analysis passed against it (PR decoration only). But that auto-created project's main branch defaulted to `master`, which was never analyzed. On push to `main`, the scanner classified `main` as a short-lived branch with no `master` baseline and failed:

```
INFO  Branch name: main, type: short
WARN  Could not find ref: master in refs/heads, ...
ERROR Project not found. Please check the 'sonar.projectKey' and 'sonar.organization' ...
ERROR sonar-scanner failed with exit code 3
```

Because the scan runs inside the publish-gating `test` job (`publish` has `needs: test`), this **blocked the 0.2.0 PyPI publish** (PyPI is still on 0.1.0; `publish`/`test-publish` were skipped).

## Change

- `sonar-project.properties`: `sonar.projectKey` → `agentculture_reachy-mini-mcp`.
- README coverage + quality-gate badge URLs and `CLAUDE.md` reference updated to the hyphenated key.
- Version bump `0.2.0 → 0.2.1` (0.2.0 never published, so PyPI goes straight to 0.2.1 once this lands).

No source or test changes — tests stay at **75 passed, 99.6% coverage**.

## Expected result

This PR's scan runs against the correctly-configured project (main branch = `main`), so PR decoration works, and on merge the push-to-`main` analysis succeeds → coverage lands on the dashboard and **0.2.1 publishes to PyPI**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- reachy-mini-mcp (Claude)
