### PR TITLE
fix(sonar): clear duplication, BLOCKER vuln, and maintainability smells

### DIFF
--- a/.env.openai.example
+++ b/.env.openai.example
@@ -27,6 +27,12 @@ OPENAI_MODEL=gpt-4-turbo-preview
 # Robot Control Server Configuration
 ROBOT_SERVER_URL=http://localhost:8100
 
+# Bind address for the OpenAI-compatible server (reachy-mini-mcp serve --openai).
+# Defaults to loopback so the server is not exposed on every interface. For a
+# Docker / cross-host deployment where other containers or machines must reach
+# it, set this to 0.0.0.0.
+REACHY_OPENAI_HOST=127.0.0.1
+
 # Reachy Mini Daemon Configuration
 REACHY_BASE_URL=http://localhost:8000
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.2.2] - 2026-06-03
+
+### Changed
+
+- Deduplicated the two server frontends: the shared daemon HTTP client (`make_request`), pose builder (`create_head_pose`), and tool-repository loaders now live once in `reachy_mini_mcp/_runtime.py` and are imported by both `server.py` and `server_openai.py` (removes the 79-line copy-paste block flagged by SonarCloud duplication).
+- OpenAI-compatible server now binds to `127.0.0.1` by default instead of `0.0.0.0`; set `REACHY_OPENAI_HOST=0.0.0.0` for Docker/cross-host deployments (resolves the BLOCKER bind-all-interfaces vulnerability, S8392).
+- Refactored `operate_robot` into focused helpers (`_run_command_sequence`, `_run_single_command`, `_execute_one_command`, `_append_state_result`, `_sequence_status`), cutting its cognitive complexity from 40 to within the allowed limit while preserving identical output.
+
+### Fixed
+
+- Cleared the remaining SonarCloud maintainability smells: duplicated string literals (now module constants), handlers that always returned the same value, unused locals/parameters, a redundant exception class, placeholder-less f-strings, and undocumented FastAPI HTTPException responses.
+
 ## [0.2.1] - 2026-06-03
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,16 +103,26 @@ This meta-tool has two modes and some implicit behavior worth knowing:
 
 ## Two servers, one set of machinery — keep them in sync
 
-`reachy_mini_mcp/server.py` and `reachy_mini_mcp/server_openai.py` each contain their own copy of `create_head_pose`, `make_request`, and the tool-loading functions. A fix to loading/dispatch logic generally needs to be applied to **both**. Both now also expose a `main()` entry point (called by `reachy-mini-mcp serve` / `serve --openai`). Known divergences to be aware of:
+`reachy_mini_mcp/server.py` and `reachy_mini_mcp/server_openai.py` share one set of
+helpers. As of 0.2.2 the byte-identical pieces — `create_head_pose`, `make_request`,
+and the tool-repository loaders (`load_tool_index` / `load_tool_definition` /
+`load_script_module`), plus the `REACHY_BASE_URL` / `TOOLS_REPOSITORY_PATH`
+constants — live **once** in `reachy_mini_mcp/_runtime.py` and are imported by both
+servers (this removed the SonarCloud duplication block). What still differs per
+server is the *tool-wrapping/registration* logic (`create_tool_function`,
+`register_tools_from_repository`), so a fix there generally needs to be applied to
+**both**. Both also expose a `main()` entry point (called by `reachy-mini-mcp serve`
+/ `serve --openai`). Known divergences to be aware of:
 
-- Both read `REACHY_BASE_URL` from the environment (defaulting to `http://localhost:8000`). (Historically `server_openai.py` hardcoded it; fixed in 0.1.0.)
+- Both read `REACHY_BASE_URL` from the environment (defaulting to `http://localhost:8000`) via `_runtime.py`. (Historically `server_openai.py` hardcoded it; fixed in 0.1.0.)
+- The OpenAI server's bind address comes from `REACHY_OPENAI_HOST` (default `127.0.0.1`); set it to `0.0.0.0` for Docker/cross-host reach. (Was hardcoded to `0.0.0.0`; fixed in 0.2.2.)
 - `server.py` builds an `inspect.Signature` with type annotations for each tool (FastMCP introspects it); `server_openai.py` doesn't need that and builds an OpenAI JSON schema instead.
 - `server.py` is a **stdio** server, so its startup banner / tool-loading prints are routed to **stderr** (stdout is the JSON-RPC channel); `server_openai.py` is HTTP, so it prints freely.
 - `server_openai.py`'s `/v1/chat/completions` is a **stub** — naive keyword matching ("turn on" → `turn_on_robot`), not a real LLM. Real LLM reasoning is expected to come from an upstream model (e.g. the vLLM containers) that then calls `/execute_tool`.
 
 ## Configuration
 
-Copy `.env.example` (MCP/TTS) or `.env.openai.example` (HTTP/LLM) to `.env`. `.env` is gitignored. Key vars: `REACHY_BASE_URL`, `PIPER_MODEL` (path **without** `.onnx`), `AUDIO_DEVICE` (ALSA device, find via `aplay -L`), and `HF_TOKEN` for the Docker stack.
+Copy `.env.example` (MCP/TTS) or `.env.openai.example` (HTTP/LLM) to `.env`. `.env` is gitignored. Key vars: `REACHY_BASE_URL`, `REACHY_OPENAI_HOST` (bind address for the `--openai` server; default `127.0.0.1`, set `0.0.0.0` for Docker), `PIPER_MODEL` (path **without** `.onnx`), `AUDIO_DEVICE` (ALSA device, find via `aplay -L`), and `HF_TOKEN` for the Docker stack.
 
 TTS (`reachy_mini_mcp/tts_queue.py`) shells out to the `piper` executable and plays WAVs with `aplay` on a background thread. If `piper`/`aplay` or a model is missing, TTS init fails gracefully and `speech` params are silently ignored.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ async def execute(make_request, create_head_pose, tts_queue, params):
 - `create_head_pose(x, y, z, roll, pitch, yaw, degrees=False, mm=False)` — builds a pose dict. When `mm=True` it converts mm→meters; when `degrees=True` it converts degrees→radians. The daemon wants **meters and radians**; antennas are passed directly in radians (e.g. `math.radians(30)`).
 - `tts_queue` — may be `None` if Piper isn't configured. Always guard: `if speech and tts_queue:`.
 
-The `execute()` signature takes **four** args — `tts_queue` is the third (it may be `None` if Piper isn't configured, so guard with `if speech and tts_queue:`). Inline-code execution was removed entirely for security (see `INLINE_REMOVAL_SUMMARY.md`); only `"type": "script"` is supported.
+The `execute()` signature takes **four** args — `tts_queue` is the third (it may be `None` if Piper isn't configured, so guard with `if speech and tts_queue:`). The loader injects all four **positionally**, so parameter *names* are not part of the runtime contract: a script that doesn't use one of them may prefix that parameter with `_` (e.g. `async def execute(make_request, _create_head_pose, _tts_queue, _params):` in the read-only `get_*` tools) to mark it intentionally unused — this is what keeps SonarCloud's S1172 quiet without a config suppression. Inline-code execution was removed entirely for security (see `INLINE_REMOVAL_SUMMARY.md`); only `"type": "script"` is supported.
 
 To register a new tool: add the script + JSON, then add an entry to `tools_index.json` and restart the server.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "reachy-mini-mcp"
-version = "0.2.1"
+version = "0.2.2"
 description = "MCP server + manager CLI for the Reachy Mini robot."
 readme = "README.md"
 license = "MIT"
@@ -75,6 +75,7 @@ source = ["reachy_mini_mcp"]
 omit = [
     "reachy_mini_mcp/__pycache__/*",
     # Robot runtime requires a daemon + hardware; unit tests cover the manager CLI.
+    "reachy_mini_mcp/_runtime.py",
     "reachy_mini_mcp/server.py",
     "reachy_mini_mcp/server_openai.py",
     "reachy_mini_mcp/tts_queue.py",

--- a/reachy_mini_mcp/_runtime.py
+++ b/reachy_mini_mcp/_runtime.py
@@ -1,0 +1,125 @@
+"""Shared robot-runtime helpers for both server frontends.
+
+``server.py`` (FastMCP/stdio) and ``server_openai.py`` (FastAPI/HTTP) used to
+carry byte-identical copies of these five helpers — the daemon HTTP client, the
+pose builder, and the tool-repository loaders. They now live here once and are
+imported by both, so a fix to loading/dispatch logic is made in a single place.
+
+This module pulls in the ``[server]`` extra (``httpx``) and talks to a live
+daemon, so it is coverage-excluded just like the server modules (see
+``pyproject.toml`` ``omit`` / ``sonar-project.properties``).
+"""
+
+import importlib.util
+import json
+import math
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import httpx
+
+# Configuration shared by both servers.
+REACHY_BASE_URL = os.getenv("REACHY_BASE_URL", "http://localhost:8000")
+TOOLS_REPOSITORY_PATH = Path(__file__).parent / "tools_repository"
+
+
+def create_head_pose(
+    x: float = 0.0,
+    y: float = 0.0,
+    z: float = 0.0,
+    roll: float = 0.0,
+    pitch: float = 0.0,
+    yaw: float = 0.0,
+    degrees: bool = False,
+    mm: bool = False,
+) -> Dict[str, Any]:
+    """
+    Create a head pose configuration for Reachy Mini.
+
+    Args:
+        x, y, z: Position offsets (meters by default, mm if mm=True)
+        roll, pitch, yaw: Rotation angles (radians by default, degrees if degrees=True)
+        degrees: If True, angles are in degrees
+        mm: If True, positions are in millimeters
+
+    Returns:
+        Dictionary with head pose configuration
+    """
+    if mm:
+        x, y, z = x / 1000, y / 1000, z / 1000
+
+    if degrees:
+        roll = math.radians(roll)
+        pitch = math.radians(pitch)
+        yaw = math.radians(yaw)
+
+    return {
+        "x": x,
+        "y": y,
+        "z": z,
+        "roll": roll,
+        "pitch": pitch,
+        "yaw": yaw,
+    }
+
+
+async def make_request(
+    method: str,
+    endpoint: str,
+    json_data: Optional[Dict] = None,
+    params: Optional[Dict] = None,
+) -> Dict[str, Any]:
+    """Make an HTTP request to the Reachy Mini daemon."""
+    url = f"{REACHY_BASE_URL}{endpoint}"
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        try:
+            if method.upper() == "GET":
+                response = await client.get(url, params=params)
+            elif method.upper() == "POST":
+                response = await client.post(url, json=json_data)
+            elif method.upper() == "PUT":
+                response = await client.put(url, json=json_data)
+            elif method.upper() == "DELETE":
+                response = await client.delete(url)
+            else:
+                raise ValueError(f"Unsupported HTTP method: {method}")
+
+            response.raise_for_status()
+            return response.json() if response.content else {"status": "success"}
+
+        except httpx.HTTPError as e:
+            return {"error": str(e), "status": "failed"}
+
+
+def load_tool_index() -> Dict[str, Any]:
+    """Load the tool index from tools_index.json."""
+    index_path = TOOLS_REPOSITORY_PATH / "tools_index.json"
+    if not index_path.exists():
+        raise FileNotFoundError(f"Tool index not found at {index_path}")
+
+    with open(index_path, "r") as f:
+        return json.load(f)
+
+
+def load_tool_definition(definition_file: str) -> Dict[str, Any]:
+    """Load a tool definition from a JSON file."""
+    def_path = TOOLS_REPOSITORY_PATH / definition_file
+    if not def_path.exists():
+        raise FileNotFoundError(f"Tool definition not found at {def_path}")
+
+    with open(def_path, "r") as f:
+        return json.load(f)
+
+
+def load_script_module(script_file: str):
+    """Dynamically load a Python script as a module."""
+    script_path = TOOLS_REPOSITORY_PATH / "scripts" / script_file
+    if not script_path.exists():
+        raise FileNotFoundError(f"Script not found at {script_path}")
+
+    spec = importlib.util.spec_from_file_location("tool_script", script_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/reachy_mini_mcp/_runtime.py
+++ b/reachy_mini_mcp/_runtime.py
@@ -18,6 +18,12 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 import httpx
+from dotenv import load_dotenv
+
+# Load .env here, before REACHY_BASE_URL is captured below. Both servers also
+# call load_dotenv(), but they import this module first — so the capture would
+# otherwise run before their load_dotenv() and ignore a .env-defined base URL.
+load_dotenv()
 
 # Configuration shared by both servers.
 REACHY_BASE_URL = os.getenv("REACHY_BASE_URL", "http://localhost:8000")

--- a/reachy_mini_mcp/cli/_clients.py
+++ b/reachy_mini_mcp/cli/_clients.py
@@ -28,6 +28,8 @@ from reachy_mini_mcp.cli._errors import EXIT_USER_ERROR, ReachyError
 CLIENTS = ("claude-code", "claude-desktop", "cursor")
 SCOPES = ("user", "project")
 
+_DESKTOP_CONFIG_FILENAME = "claude_desktop_config.json"
+
 
 @dataclass
 class ClientTarget:
@@ -42,12 +44,12 @@ class ClientTarget:
 def _claude_desktop_path() -> Path:
     home = Path.home()
     if sys.platform == "darwin":
-        return home / "Library" / "Application Support" / "Claude" / "claude_desktop_config.json"
+        return home / "Library" / "Application Support" / "Claude" / _DESKTOP_CONFIG_FILENAME
     if sys.platform.startswith("win"):
         base = os.environ.get("APPDATA")
         root = Path(base) if base else home / "AppData" / "Roaming"
-        return root / "Claude" / "claude_desktop_config.json"
-    return home / ".config" / "Claude" / "claude_desktop_config.json"
+        return root / "Claude" / _DESKTOP_CONFIG_FILENAME
+    return home / ".config" / "Claude" / _DESKTOP_CONFIG_FILENAME
 
 
 def resolve_target(

--- a/reachy_mini_mcp/cli/_commands/install.py
+++ b/reachy_mini_mcp/cli/_commands/install.py
@@ -75,7 +75,7 @@ def _add_target_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def _handle(args: argparse.Namespace) -> int:
+def _handle(args: argparse.Namespace) -> None:
     target = _clients.resolve_target(client=args.client, scope=args.scope, path=args.path)
     entry = _mcp.build_entry(base_url=args.base_url, dev=args.dev)
     config = _clients.load_config(target.path)
@@ -84,12 +84,11 @@ def _handle(args: argparse.Namespace) -> int:
     if args.dry_run:
         emit_diagnostic(f"# would write {target.label}")
         emit_result(json.dumps(config, indent=2))
-        return 0
+        return
 
     if not changed:
         emit_diagnostic(f"{args.name!r} already registered in {target.label} — no change.")
-        return 0
+        return
 
     _clients.write_config(target.path, config)
     emit_diagnostic(f"Installed {args.name!r} → {target.label}")
-    return 0

--- a/reachy_mini_mcp/cli/_commands/serve.py
+++ b/reachy_mini_mcp/cli/_commands/serve.py
@@ -30,7 +30,6 @@ def register(sub: argparse._SubParsersAction) -> None:
 
 
 def _handle(args: argparse.Namespace) -> int:
-    module = "server_openai" if args.openai else "server"
     try:
         if args.openai:
             from reachy_mini_mcp.server_openai import main as serve_main

--- a/reachy_mini_mcp/cli/_commands/uninstall.py
+++ b/reachy_mini_mcp/cli/_commands/uninstall.py
@@ -33,7 +33,7 @@ def register(sub: argparse._SubParsersAction) -> None:
     parser.set_defaults(func=_handle)
 
 
-def _handle(args: argparse.Namespace) -> int:
+def _handle(args: argparse.Namespace) -> None:
     target = _clients.resolve_target(client=args.client, scope=args.scope, path=args.path)
     config = _clients.load_config(target.path)
     removed = _clients.remove_entry(config, name=args.name)
@@ -41,12 +41,11 @@ def _handle(args: argparse.Namespace) -> int:
     if args.dry_run:
         emit_diagnostic(f"# would write {target.label}")
         emit_result(json.dumps(config, indent=2))
-        return 0
+        return
 
     if not removed:
         emit_diagnostic(f"{args.name!r} not found in {target.label} — nothing to do.")
-        return 0
+        return
 
     _clients.write_config(target.path, config)
     emit_diagnostic(f"Removed {args.name!r} from {target.label}")
-    return 0

--- a/reachy_mini_mcp/cli/_meta.py
+++ b/reachy_mini_mcp/cli/_meta.py
@@ -50,6 +50,6 @@ def daemon_status(base_url: str, *, timeout: float = 2.0) -> Tuple[bool, str]:
             return True, f"HTTP {resp.status}"
     except urllib.error.HTTPError as exc:
         return True, f"HTTP {exc.code}"
-    except (urllib.error.URLError, OSError, ValueError) as exc:
+    except (OSError, ValueError) as exc:  # urllib.error.URLError is an OSError subclass
         reason = getattr(exc, "reason", exc)
         return False, str(reason)

--- a/reachy_mini_mcp/server.py
+++ b/reachy_mini_mcp/server.py
@@ -11,16 +11,20 @@ This version uses a repository-based approach for defining tools dynamically.
 
 import sys
 import contextlib
-import httpx
 import json
 import os
-import math
-import asyncio
-import importlib.util
-from pathlib import Path
 from typing import Optional, Dict, Any, List
 from dotenv import load_dotenv
 from fastmcp import FastMCP
+from reachy_mini_mcp._runtime import (
+    REACHY_BASE_URL,
+    TOOLS_REPOSITORY_PATH,
+    create_head_pose,
+    make_request,
+    load_tool_index,
+    load_tool_definition,
+    load_script_module,
+)
 from reachy_mini_mcp.tts_queue import AsyncTTSQueue
 
 # Load environment variables from .env file
@@ -29,116 +33,8 @@ load_dotenv()
 # Initialize FastMCP server
 mcp = FastMCP("Reachy Mini Controller")
 
-# Configuration
-REACHY_BASE_URL = os.getenv("REACHY_BASE_URL", "http://localhost:8000")
-TOOLS_REPOSITORY_PATH = Path(__file__).parent / "tools_repository"
-
 # TTS Queue (initialized in initialize_server)
 tts_queue = None
-
-
-# Helper functions
-def create_head_pose(
-    x: float = 0.0,
-    y: float = 0.0, 
-    z: float = 0.0,
-    roll: float = 0.0,
-    pitch: float = 0.0,
-    yaw: float = 0.0,
-    degrees: bool = False,
-    mm: bool = False
-) -> Dict[str, Any]:
-    """
-    Create a head pose configuration for Reachy Mini.
-    
-    Args:
-        x, y, z: Position offsets (meters by default, mm if mm=True)
-        roll, pitch, yaw: Rotation angles (radians by default, degrees if degrees=True)
-        degrees: If True, angles are in degrees
-        mm: If True, positions are in millimeters
-    
-    Returns:
-        Dictionary with head pose configuration
-    """
-    if mm:
-        x, y, z = x / 1000, y / 1000, z / 1000
-    
-    if degrees:
-        roll = math.radians(roll)
-        pitch = math.radians(pitch)
-        yaw = math.radians(yaw)
-    
-    return {
-        "x": x,
-        "y": y,
-        "z": z,
-        "roll": roll,
-        "pitch": pitch,
-        "yaw": yaw
-    }
-
-
-async def make_request(
-    method: str,
-    endpoint: str,
-    json_data: Optional[Dict] = None,
-    params: Optional[Dict] = None
-) -> Dict[str, Any]:
-    """Make an HTTP request to the Reachy Mini daemon."""
-    url = f"{REACHY_BASE_URL}{endpoint}"
-    
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        try:
-            if method.upper() == "GET":
-                response = await client.get(url, params=params)
-            elif method.upper() == "POST":
-                response = await client.post(url, json=json_data)
-            elif method.upper() == "PUT":
-                response = await client.put(url, json=json_data)
-            elif method.upper() == "DELETE":
-                response = await client.delete(url)
-            else:
-                raise ValueError(f"Unsupported HTTP method: {method}")
-            
-            response.raise_for_status()
-            return response.json() if response.content else {"status": "success"}
-            
-        except httpx.HTTPError as e:
-            return {"error": str(e), "status": "failed"}
-
-
-# Dynamic tool loading functions
-
-def load_tool_index() -> Dict[str, Any]:
-    """Load the tool index from tools_index.json."""
-    index_path = TOOLS_REPOSITORY_PATH / "tools_index.json"
-    if not index_path.exists():
-        raise FileNotFoundError(f"Tool index not found at {index_path}")
-    
-    with open(index_path, 'r') as f:
-        return json.load(f)
-
-
-def load_tool_definition(definition_file: str) -> Dict[str, Any]:
-    """Load a tool definition from a JSON file."""
-    def_path = TOOLS_REPOSITORY_PATH / definition_file
-    if not def_path.exists():
-        raise FileNotFoundError(f"Tool definition not found at {def_path}")
-    
-    with open(def_path, 'r') as f:
-        return json.load(f)
-
-
-def load_script_module(script_file: str):
-    """Dynamically load a Python script as a module."""
-    script_path = TOOLS_REPOSITORY_PATH / "scripts" / script_file
-    if not script_path.exists():
-        raise FileNotFoundError(f"Script not found at {script_path}")
-    
-    spec = importlib.util.spec_from_file_location("tool_script", script_path)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
 
 
 def create_tool_function(tool_def: Dict[str, Any]):
@@ -366,6 +262,160 @@ def get_tool_registry() -> Dict[str, Any]:
     return TOOL_REGISTRY
 
 
+def _sequence_status(failed_count: int, total: int) -> str:
+    """Summary status for a command sequence (no failures / some / all failed)."""
+    if failed_count == 0:
+        return "success"
+    if failed_count < total:
+        return "partial"
+    return "failed"
+
+
+async def _execute_one_command(registry, idx, command):
+    """Run a single command from a sequence. Returns ``(result_dict, failed)``."""
+    if not isinstance(command, dict):
+        return {
+            "command_index": idx,
+            "error": "Each command must be a dictionary",
+            "status": "failed"
+        }, True
+
+    cmd_tool_name = command.get("tool_name")
+    cmd_parameters = command.get("parameters", {})
+
+    if not cmd_tool_name:
+        return {
+            "command_index": idx,
+            "error": "Missing 'tool_name' in command",
+            "status": "failed"
+        }, True
+
+    if cmd_tool_name not in registry:
+        available_tools = ", ".join(sorted(registry.keys()))
+        return {
+            "command_index": idx,
+            "tool_name": cmd_tool_name,
+            "error": f"Tool '{cmd_tool_name}' not found",
+            "available_tools": available_tools,
+            "status": "failed"
+        }, True
+
+    try:
+        tool_func = registry[cmd_tool_name]
+        result = await tool_func(**cmd_parameters)
+        return {
+            "command_index": idx,
+            "tool": cmd_tool_name,
+            "parameters": cmd_parameters,
+            "result": result,
+            "status": "success"
+        }, False
+    except Exception as e:
+        return {
+            "command_index": idx,
+            "tool": cmd_tool_name,
+            "parameters": cmd_parameters,
+            "error": str(e),
+            "status": "failed"
+        }, True
+
+
+async def _append_state_result(registry, results, command_index):
+    """Auto-append a ``get_robot_state`` result at the end of a sequence."""
+    try:
+        if "get_robot_state" in registry:
+            tool_func = registry["get_robot_state"]
+            state_result = await tool_func()
+            results.append({
+                "command_index": command_index,
+                "tool": "get_robot_state",
+                "parameters": {},
+                "result": state_result,
+                "status": "success",
+                "auto_appended": True
+            })
+    except Exception as e:
+        results.append({
+            "command_index": command_index,
+            "tool": "get_robot_state",
+            "parameters": {},
+            "error": str(e),
+            "status": "failed",
+            "auto_appended": True
+        })
+
+
+async def _run_command_sequence(registry, commands):
+    """Sequence mode: run each command, then auto-append the robot state."""
+    if not isinstance(commands, list):
+        return {
+            "error": "commands parameter must be a list of command dictionaries",
+            "status": "failed"
+        }
+
+    results = []
+    failed_count = 0
+    for idx, command in enumerate(commands):
+        result, failed = await _execute_one_command(registry, idx, command)
+        results.append(result)
+        if failed:
+            failed_count += 1
+
+    await _append_state_result(registry, results, len(commands))
+
+    return {
+        "mode": "sequence",
+        "total_commands": len(commands),
+        "successful": len(commands) - failed_count,
+        "failed": failed_count,
+        "results": results,
+        "status": _sequence_status(failed_count, len(commands))
+    }
+
+
+async def _run_single_command(registry, tool_name, parameters):
+    """Single command mode (backward compatible): run it, then attach robot state."""
+    if parameters is None:
+        parameters = {}
+
+    if tool_name not in registry:
+        available_tools = ", ".join(sorted(registry.keys()))
+        return {
+            "error": f"Tool '{tool_name}' not found",
+            "available_tools": available_tools,
+            "registry_size": len(registry),
+            "status": "failed"
+        }
+
+    try:
+        tool_func = registry[tool_name]
+        result = await tool_func(**parameters)
+
+        # Automatically get robot state after execution (unless already getting state)
+        robot_state = None
+        if tool_name != "get_robot_state" and "get_robot_state" in registry:
+            try:
+                state_func = registry["get_robot_state"]
+                robot_state = await state_func()
+            except Exception as state_error:
+                robot_state = {"error": str(state_error)}
+
+        return {
+            "tool": tool_name,
+            "parameters": parameters,
+            "result": result,
+            "robot_state": robot_state,
+            "status": "success"
+        }
+    except Exception as e:
+        return {
+            "tool": tool_name,
+            "parameters": parameters,
+            "error": str(e),
+            "status": "failed"
+        }
+
+
 # Meta-tool for operating the robot dynamically
 # Note: This is registered manually in initialize_server() after all tools are loaded
 async def operate_robot(
@@ -432,158 +482,18 @@ async def operate_robot(
             {"tool_name": "look_at_direction", "parameters": {"direction": "left", "duration": 1.0}}
         ])
     """
-    # Get the current tool registry
+    # Thin dispatcher — the per-mode logic lives in the helpers above so this
+    # meta-tool stays simple (and FastMCP only introspects this signature/docstring).
     registry = get_tool_registry()
-    
-    # Determine mode: sequence or single command
+
     if commands is not None:
-        # Sequence mode
-        if not isinstance(commands, list):
-            return {
-                "error": "commands parameter must be a list of command dictionaries",
-                "status": "failed"
-            }
-        
-        results = []
-        failed_count = 0
-        
-        for idx, command in enumerate(commands):
-            if not isinstance(command, dict):
-                results.append({
-                    "command_index": idx,
-                    "error": "Each command must be a dictionary",
-                    "status": "failed"
-                })
-                failed_count += 1
-                continue
-            
-            cmd_tool_name = command.get("tool_name")
-            cmd_parameters = command.get("parameters", {})
-            
-            if not cmd_tool_name:
-                results.append({
-                    "command_index": idx,
-                    "error": "Missing 'tool_name' in command",
-                    "status": "failed"
-                })
-                failed_count += 1
-                continue
-            
-            # Check if tool exists
-            if cmd_tool_name not in registry:
-                available_tools = ", ".join(sorted(registry.keys()))
-                results.append({
-                    "command_index": idx,
-                    "tool_name": cmd_tool_name,
-                    "error": f"Tool '{cmd_tool_name}' not found",
-                    "available_tools": available_tools,
-                    "status": "failed"
-                })
-                failed_count += 1
-                continue
-            
-            # Execute the command
-            try:
-                tool_func = registry[cmd_tool_name]
-                result = await tool_func(**cmd_parameters)
-                results.append({
-                    "command_index": idx,
-                    "tool": cmd_tool_name,
-                    "parameters": cmd_parameters,
-                    "result": result,
-                    "status": "success"
-                })
-            except Exception as e:
-                results.append({
-                    "command_index": idx,
-                    "tool": cmd_tool_name,
-                    "parameters": cmd_parameters,
-                    "error": str(e),
-                    "status": "failed"
-                })
-                failed_count += 1
-        
-        # Automatically append get_robot_state at the end
-        try:
-            if "get_robot_state" in registry:
-                tool_func = registry["get_robot_state"]
-                state_result = await tool_func()
-                results.append({
-                    "command_index": len(commands),
-                    "tool": "get_robot_state",
-                    "parameters": {},
-                    "result": state_result,
-                    "status": "success",
-                    "auto_appended": True
-                })
-        except Exception as e:
-            results.append({
-                "command_index": len(commands),
-                "tool": "get_robot_state",
-                "parameters": {},
-                "error": str(e),
-                "status": "failed",
-                "auto_appended": True
-            })
-        
-        return {
-            "mode": "sequence",
-            "total_commands": len(commands),
-            "successful": len(commands) - failed_count,
-            "failed": failed_count,
-            "results": results,
-            "status": "success" if failed_count == 0 else "partial" if failed_count < len(commands) else "failed"
-        }
-    
-    elif tool_name is not None:
-        # Single command mode (backward compatible)
-        if parameters is None:
-            parameters = {}
-        
-        # Check if tool exists in registry
-        if tool_name not in registry:
-            available_tools = ", ".join(sorted(registry.keys()))
-            return {
-                "error": f"Tool '{tool_name}' not found",
-                "available_tools": available_tools,
-                "registry_size": len(registry),
-                "status": "failed"
-            }
-        
-        try:
-            # Execute the tool
-            tool_func = registry[tool_name]
-            result = await tool_func(**parameters)
-            
-            # Automatically get robot state after execution (unless already getting state)
-            robot_state = None
-            if tool_name != "get_robot_state" and "get_robot_state" in registry:
-                try:
-                    state_func = registry["get_robot_state"]
-                    robot_state = await state_func()
-                except Exception as state_error:
-                    robot_state = {"error": str(state_error)}
-            
-            return {
-                "tool": tool_name,
-                "parameters": parameters,
-                "result": result,
-                "robot_state": robot_state,
-                "status": "success"
-            }
-        except Exception as e:
-            return {
-                "tool": tool_name,
-                "parameters": parameters,
-                "error": str(e),
-                "status": "failed"
-            }
-    
-    else:
-        return {
-            "error": "Must provide either 'tool_name' for single command or 'commands' for sequence",
-            "status": "failed"
-        }
+        return await _run_command_sequence(registry, commands)
+    if tool_name is not None:
+        return await _run_single_command(registry, tool_name, parameters)
+    return {
+        "error": "Must provide either 'tool_name' for single command or 'commands' for sequence",
+        "status": "failed"
+    }
 
 
 # Initialize and run
@@ -627,7 +537,7 @@ def initialize_server():
     # All other tools are loaded into the registry but not exposed as individual MCP tools
     mcp.tool()(operate_robot)
     print("✓ Registered MCP tool: operate_robot (meta-tool for all robot operations)")
-    print(f"✓ Individual tools are available via operate_robot but not as separate MCP tools")
+    print("✓ Individual tools are available via operate_robot but not as separate MCP tools")
     
     print("=" * 60)
     print("Server initialized and ready!")

--- a/reachy_mini_mcp/server_openai.py
+++ b/reachy_mini_mcp/server_openai.py
@@ -12,18 +12,22 @@ The server communicates with the Reachy Mini daemon running on localhost:8000.
 This version uses a repository-based approach for defining tools dynamically.
 """
 
-import httpx
 import json
 import os
-import math
 import asyncio
-import importlib.util
-from pathlib import Path
 from typing import Optional, Dict, Any, List
 from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException
-from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
+from reachy_mini_mcp._runtime import (
+    REACHY_BASE_URL,
+    TOOLS_REPOSITORY_PATH,
+    create_head_pose,
+    make_request,
+    load_tool_index,
+    load_tool_definition,
+    load_script_module,
+)
 from reachy_mini_mcp.tts_queue import AsyncTTSQueue
 import uvicorn
 
@@ -36,10 +40,6 @@ app = FastAPI(
     description="OpenAI-compatible API for controlling Reachy Mini robot",
     version="1.0.0"
 )
-
-# Configuration
-REACHY_BASE_URL = os.getenv("REACHY_BASE_URL", "http://localhost:8000")
-TOOLS_REPOSITORY_PATH = Path(__file__).parent / "tools_repository"
 
 # TTS Queue (initialized in startup)
 tts_queue = None
@@ -73,100 +73,6 @@ class ChatCompletionRequest(BaseModel):
     tool_choice: Optional[str] = Field("auto", description="Tool choice strategy")
     temperature: Optional[float] = Field(0.7, description="Sampling temperature")
     max_tokens: Optional[int] = Field(3000, description="Maximum tokens to generate")
-
-
-# Helper functions
-
-def create_head_pose(
-    x: float = 0.0,
-    y: float = 0.0, 
-    z: float = 0.0,
-    roll: float = 0.0,
-    pitch: float = 0.0,
-    yaw: float = 0.0,
-    degrees: bool = False,
-    mm: bool = False
-) -> Dict[str, Any]:
-    """Create a head pose configuration for Reachy Mini."""
-    if mm:
-        x, y, z = x / 1000, y / 1000, z / 1000
-    
-    if degrees:
-        roll = math.radians(roll)
-        pitch = math.radians(pitch)
-        yaw = math.radians(yaw)
-    
-    return {
-        "x": x,
-        "y": y,
-        "z": z,
-        "roll": roll,
-        "pitch": pitch,
-        "yaw": yaw
-    }
-
-
-async def make_request(
-    method: str,
-    endpoint: str,
-    json_data: Optional[Dict] = None,
-    params: Optional[Dict] = None
-) -> Dict[str, Any]:
-    """Make an HTTP request to the Reachy Mini daemon."""
-    url = f"{REACHY_BASE_URL}{endpoint}"
-    
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        try:
-            if method.upper() == "GET":
-                response = await client.get(url, params=params)
-            elif method.upper() == "POST":
-                response = await client.post(url, json=json_data)
-            elif method.upper() == "PUT":
-                response = await client.put(url, json=json_data)
-            elif method.upper() == "DELETE":
-                response = await client.delete(url)
-            else:
-                raise ValueError(f"Unsupported HTTP method: {method}")
-            
-            response.raise_for_status()
-            return response.json() if response.content else {"status": "success"}
-            
-        except httpx.HTTPError as e:
-            return {"error": str(e), "status": "failed"}
-
-
-# Dynamic tool loading functions
-
-def load_tool_index() -> Dict[str, Any]:
-    """Load the tool index from tools_index.json."""
-    index_path = TOOLS_REPOSITORY_PATH / "tools_index.json"
-    if not index_path.exists():
-        raise FileNotFoundError(f"Tool index not found at {index_path}")
-    
-    with open(index_path, 'r') as f:
-        return json.load(f)
-
-
-def load_tool_definition(definition_file: str) -> Dict[str, Any]:
-    """Load a tool definition from a JSON file."""
-    def_path = TOOLS_REPOSITORY_PATH / definition_file
-    if not def_path.exists():
-        raise FileNotFoundError(f"Tool definition not found at {def_path}")
-    
-    with open(def_path, 'r') as f:
-        return json.load(f)
-
-
-def load_script_module(script_file: str):
-    """Dynamically load a Python script as a module."""
-    script_path = TOOLS_REPOSITORY_PATH / "scripts" / script_file
-    if not script_path.exists():
-        raise FileNotFoundError(f"Script not found at {script_path}")
-    
-    spec = importlib.util.spec_from_file_location("tool_script", script_path)
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
 
 
 def convert_tool_to_openai_format(tool_def: Dict[str, Any]) -> Dict[str, Any]:
@@ -302,7 +208,13 @@ async def get_tools():
     return {"tools": tools}
 
 
-@app.post("/execute_tool")
+@app.post(
+    "/execute_tool",
+    responses={
+        404: {"description": "Tool not found in the registry"},
+        500: {"description": "Tool raised an error during execution"},
+    },
+)
 async def execute_tool(request: ToolExecutionRequest):
     """Execute a tool with given arguments."""
     tool_name = request.tool_name
@@ -325,7 +237,10 @@ async def execute_tool(request: ToolExecutionRequest):
         )
 
 
-@app.post("/v1/chat/completions")
+@app.post(
+    "/v1/chat/completions",
+    responses={400: {"description": "No user message found in the request"}},
+)
 async def chat_completions(request: ChatCompletionRequest):
     """
     OpenAI-compatible chat completions endpoint.
@@ -469,10 +384,17 @@ async def shutdown_event():
 
 def main() -> None:
     """Console entry point (``reachy-mini-mcp serve --openai``): run the
-    OpenAI-compatible FastAPI server on port 8100."""
+    OpenAI-compatible FastAPI server on port 8100.
+
+    The bind address defaults to loopback (``127.0.0.1``) so the server is not
+    exposed on every interface by default. Containerized / cross-host
+    deployments that need it reachable from other machines set
+    ``REACHY_OPENAI_HOST=0.0.0.0`` explicitly.
+    """
+    host = os.getenv("REACHY_OPENAI_HOST", "127.0.0.1")
     uvicorn.run(
         app,
-        host="0.0.0.0",
+        host=host,
         port=8100,
         log_level="info"
     )

--- a/reachy_mini_mcp/tools_repository/scripts/express_emotion.py
+++ b/reachy_mini_mcp/tools_repository/scripts/express_emotion.py
@@ -1,6 +1,8 @@
 """Script for expressing emotions with the robot."""
 import math
 
+GOTO_ENDPOINT = "/api/move/goto"
+
 
 async def execute(make_request, create_head_pose, tts_queue, params):
     """
@@ -22,7 +24,7 @@ async def execute(make_request, create_head_pose, tts_queue, params):
     if emotion == "happy":
         # Lift head slightly and antennas up
         head_pose = create_head_pose(z=5, pitch=-5, degrees=True, mm=True)
-        await make_request("POST", "/api/move/goto", json_data={
+        await make_request("POST", GOTO_ENDPOINT, json_data={
             "head_pose": head_pose,
             "antennas": [math.radians(30), math.radians(30)],
             "duration": 1.5
@@ -31,7 +33,7 @@ async def execute(make_request, create_head_pose, tts_queue, params):
     elif emotion == "sad":
         # Lower head and antennas down
         head_pose = create_head_pose(z=-5, pitch=10, degrees=True, mm=True)
-        await make_request("POST", "/api/move/goto", json_data={
+        await make_request("POST", GOTO_ENDPOINT, json_data={
             "head_pose": head_pose,
             "antennas": [math.radians(-20), math.radians(-20)],
             "duration": 2.0
@@ -40,7 +42,7 @@ async def execute(make_request, create_head_pose, tts_queue, params):
     elif emotion == "curious":
         # Tilt head to the side
         head_pose = create_head_pose(roll=20, degrees=True)
-        await make_request("POST", "/api/move/goto", json_data={
+        await make_request("POST", GOTO_ENDPOINT, json_data={
             "head_pose": head_pose,
             "antennas": [math.radians(15), math.radians(-15)],
             "duration": 1.5
@@ -49,7 +51,7 @@ async def execute(make_request, create_head_pose, tts_queue, params):
     elif emotion == "surprised":
         # Quick upward movement
         head_pose = create_head_pose(z=10, pitch=-15, degrees=True, mm=True)
-        await make_request("POST", "/api/move/goto", json_data={
+        await make_request("POST", GOTO_ENDPOINT, json_data={
             "head_pose": head_pose,
             "antennas": [math.radians(45), math.radians(45)],
             "duration": 0.8
@@ -58,7 +60,7 @@ async def execute(make_request, create_head_pose, tts_queue, params):
     elif emotion == "confused":
         # Alternate antenna positions
         head_pose = create_head_pose(roll=15, degrees=True)
-        await make_request("POST", "/api/move/goto", json_data={
+        await make_request("POST", GOTO_ENDPOINT, json_data={
             "head_pose": head_pose,
             "antennas": [math.radians(25), math.radians(-25)],
             "duration": 1.5
@@ -66,7 +68,7 @@ async def execute(make_request, create_head_pose, tts_queue, params):
         
     else:  # neutral
         pose = create_head_pose()
-        await make_request("POST", "/api/move/goto", json_data={"head_pose": pose, "duration": 2.0})
+        await make_request("POST", GOTO_ENDPOINT, json_data={"head_pose": pose, "duration": 2.0})
     
     return {"status": "success", "emotion": emotion}
 

--- a/reachy_mini_mcp/tools_repository/scripts/get_antennas_state.py
+++ b/reachy_mini_mcp/tools_repository/scripts/get_antennas_state.py
@@ -4,7 +4,7 @@ Gets the current state of the robot's antennas.
 """
 
 
-async def execute(make_request, create_head_pose, tts_queue, params):
+async def execute(make_request, _create_head_pose, _tts_queue, _params):
     """Execute the get_antennas_state tool."""
     full_state = await make_request('GET', '/api/state/full')
     

--- a/reachy_mini_mcp/tools_repository/scripts/get_head_state.py
+++ b/reachy_mini_mcp/tools_repository/scripts/get_head_state.py
@@ -4,7 +4,7 @@ Gets the current state of the robot's head.
 """
 
 
-async def execute(make_request, create_head_pose, tts_queue, params):
+async def execute(make_request, _create_head_pose, _tts_queue, _params):
     """Execute the get_head_state tool."""
     full_state = await make_request('GET', '/api/state/full')
     

--- a/reachy_mini_mcp/tools_repository/scripts/get_health_status.py
+++ b/reachy_mini_mcp/tools_repository/scripts/get_health_status.py
@@ -4,7 +4,7 @@ Gets the overall health status of the robot.
 """
 
 
-async def execute(make_request, create_head_pose, tts_queue, params):
+async def execute(make_request, _create_head_pose, _tts_queue, _params):
     """Execute the get_health_status tool."""
     return await make_request('GET', '/api/daemon/status')
 

--- a/reachy_mini_mcp/tools_repository/scripts/get_power_state.py
+++ b/reachy_mini_mcp/tools_repository/scripts/get_power_state.py
@@ -4,7 +4,7 @@ Gets the current power state of the robot.
 """
 
 
-async def execute(make_request, create_head_pose, tts_queue, params):
+async def execute(make_request, _create_head_pose, _tts_queue, _params):
     """Execute the get_power_state tool."""
     return await make_request('GET', '/api/motors/status')
 

--- a/reachy_mini_mcp/tools_repository/scripts/get_robot_state.py
+++ b/reachy_mini_mcp/tools_repository/scripts/get_robot_state.py
@@ -4,7 +4,7 @@ Gets the current full state of the Reachy Mini robot.
 """
 
 
-async def execute(make_request, create_head_pose, tts_queue, params):
+async def execute(make_request, _create_head_pose, _tts_queue, _params):
     """Execute the get_robot_state tool."""
     return await make_request('GET', '/api/state/full')
 

--- a/reachy_mini_mcp/tools_repository/scripts/move_antennas.py
+++ b/reachy_mini_mcp/tools_repository/scripts/move_antennas.py
@@ -5,7 +5,7 @@ Moves the robot's antennas independently.
 import math
 
 
-async def execute(make_request, create_head_pose, tts_queue, params):
+async def execute(make_request, _create_head_pose, tts_queue, params):
     """Execute the move_antennas tool."""
     left = params.get('left')
     right = params.get('right')

--- a/reachy_mini_mcp/tools_repository/scripts/perform_gesture.py
+++ b/reachy_mini_mcp/tools_repository/scripts/perform_gesture.py
@@ -2,6 +2,8 @@
 import asyncio
 import math
 
+GOTO_ENDPOINT = "/api/move/goto"
+
 
 async def execute(make_request, create_head_pose, tts_queue, params):
     """
@@ -25,43 +27,43 @@ async def execute(make_request, create_head_pose, tts_queue, params):
         duration = 0.8
         angle = 10
         pose_down = create_head_pose(pitch=angle, degrees=True)
-        await make_request("POST", "/api/move/goto", json_data={"head_pose": pose_down, "duration": duration})
+        await make_request("POST", GOTO_ENDPOINT, json_data={"head_pose": pose_down, "duration": duration})
         await asyncio.sleep(duration)
         pose_neutral = create_head_pose()
-        await make_request("POST", "/api/move/goto", json_data={"head_pose": pose_neutral, "duration": duration})
+        await make_request("POST", GOTO_ENDPOINT, json_data={"head_pose": pose_neutral, "duration": duration})
         
         await asyncio.sleep(0.5)
-        await make_request("POST", "/api/move/goto", json_data={"antennas": [math.radians(30), math.radians(30)], "duration": 0.5})
+        await make_request("POST", GOTO_ENDPOINT, json_data={"antennas": [math.radians(30), math.radians(30)], "duration": 0.5})
         await asyncio.sleep(0.5)
-        await make_request("POST", "/api/move/goto", json_data={"antennas": [0.0, 0.0], "duration": 2.0})
+        await make_request("POST", GOTO_ENDPOINT, json_data={"antennas": [0.0, 0.0], "duration": 2.0})
         
     elif gesture == "yes":
         # Nod yes
         duration = 0.8
         angle = 20
         pose_down = create_head_pose(pitch=angle, degrees=True)
-        await make_request("POST", "/api/move/goto", json_data={"head_pose": pose_down, "duration": duration})
+        await make_request("POST", GOTO_ENDPOINT, json_data={"head_pose": pose_down, "duration": duration})
         await asyncio.sleep(duration)
         pose_neutral = create_head_pose()
-        return await make_request("POST", "/api/move/goto", json_data={"head_pose": pose_neutral, "duration": duration})
+        return await make_request("POST", GOTO_ENDPOINT, json_data={"head_pose": pose_neutral, "duration": duration})
         
     elif gesture == "no":
         # Shake no
         duration = 0.7
         angle = 25
         pose_left = create_head_pose(yaw=-angle, degrees=True)
-        await make_request("POST", "/api/move/goto", json_data={"head_pose": pose_left, "duration": duration})
+        await make_request("POST", GOTO_ENDPOINT, json_data={"head_pose": pose_left, "duration": duration})
         await asyncio.sleep(duration)
         pose_right = create_head_pose(yaw=angle, degrees=True)
-        await make_request("POST", "/api/move/goto", json_data={"head_pose": pose_right, "duration": duration})
+        await make_request("POST", GOTO_ENDPOINT, json_data={"head_pose": pose_right, "duration": duration})
         await asyncio.sleep(duration)
         pose_neutral = create_head_pose()
-        return await make_request("POST", "/api/move/goto", json_data={"head_pose": pose_neutral, "duration": duration})
+        return await make_request("POST", GOTO_ENDPOINT, json_data={"head_pose": pose_neutral, "duration": duration})
         
     elif gesture == "thinking":
         # Tilt head and one antenna
         head_pose = create_head_pose(roll=15, pitch=5, degrees=True)
-        await make_request("POST", "/api/move/goto", json_data={
+        await make_request("POST", GOTO_ENDPOINT, json_data={
             "head_pose": head_pose,
             "antennas": [math.radians(20), math.radians(-10)],
             "duration": 1.5
@@ -70,11 +72,11 @@ async def execute(make_request, create_head_pose, tts_queue, params):
     elif gesture == "celebration":
         # Excited movements
         for _ in range(2):
-            await make_request("POST", "/api/move/goto", json_data={"antennas": [math.radians(40), math.radians(40)], "duration": 0.4})
+            await make_request("POST", GOTO_ENDPOINT, json_data={"antennas": [math.radians(40), math.radians(40)], "duration": 0.4})
             await asyncio.sleep(0.4)
-            await make_request("POST", "/api/move/goto", json_data={"antennas": [math.radians(-20), math.radians(-20)], "duration": 0.4})
+            await make_request("POST", GOTO_ENDPOINT, json_data={"antennas": [math.radians(-20), math.radians(-20)], "duration": 0.4})
             await asyncio.sleep(0.4)
-        await make_request("POST", "/api/move/goto", json_data={"antennas": [0.0, 0.0], "duration": 2.0})
+        await make_request("POST", GOTO_ENDPOINT, json_data={"antennas": [0.0, 0.0], "duration": 2.0})
     
     return {"status": "success", "gesture": gesture}
 

--- a/reachy_mini_mcp/tools_repository/scripts/reset_antennas.py
+++ b/reachy_mini_mcp/tools_repository/scripts/reset_antennas.py
@@ -4,7 +4,7 @@ Resets both antennas to their neutral position (0 degrees).
 """
 
 
-async def execute(make_request, create_head_pose, tts_queue, params):
+async def execute(make_request, _create_head_pose, tts_queue, params):
     """Execute the reset_antennas tool."""
     speech = params.get('speech')
     

--- a/reachy_mini_mcp/tools_repository/scripts/shake_head.py
+++ b/reachy_mini_mcp/tools_repository/scripts/shake_head.py
@@ -1,6 +1,8 @@
 """Script for shaking the robot's head."""
 import asyncio
 
+GOTO_ENDPOINT = "/api/move/goto"
+
 
 async def execute(make_request, create_head_pose, tts_queue, params):
     """
@@ -22,16 +24,16 @@ async def execute(make_request, create_head_pose, tts_queue, params):
     
     # Shake left
     pose_left = create_head_pose(yaw=-angle, degrees=True)
-    await make_request("POST", "/api/move/goto", json_data={"head_pose": pose_left, "duration": duration})
+    await make_request("POST", GOTO_ENDPOINT, json_data={"head_pose": pose_left, "duration": duration})
     await asyncio.sleep(duration)
     
     # Shake right
     pose_right = create_head_pose(yaw=angle, degrees=True)
-    await make_request("POST", "/api/move/goto", json_data={"head_pose": pose_right, "duration": duration})
+    await make_request("POST", GOTO_ENDPOINT, json_data={"head_pose": pose_right, "duration": duration})
     await asyncio.sleep(duration)
     
     # Return to neutral
     pose_neutral = create_head_pose()
-    return await make_request("POST", "/api/move/goto", json_data={"head_pose": pose_neutral, "duration": duration})
+    return await make_request("POST", GOTO_ENDPOINT, json_data={"head_pose": pose_neutral, "duration": duration})
 
 

--- a/reachy_mini_mcp/tools_repository/scripts/stop_all_movements.py
+++ b/reachy_mini_mcp/tools_repository/scripts/stop_all_movements.py
@@ -4,7 +4,7 @@ Emergency stop - immediately halts all robot movements.
 """
 
 
-async def execute(make_request, create_head_pose, tts_queue, params):
+async def execute(make_request, _create_head_pose, tts_queue, params):
     """Execute the stop_all_movements tool."""
     speech = params.get('speech')
     

--- a/reachy_mini_mcp/tools_repository/scripts/turn_off_robot.py
+++ b/reachy_mini_mcp/tools_repository/scripts/turn_off_robot.py
@@ -4,7 +4,7 @@ Turns off the robot's motors and deactivates systems.
 """
 
 
-async def execute(make_request, create_head_pose, tts_queue, params):
+async def execute(make_request, _create_head_pose, tts_queue, params):
     """Execute the turn_off_robot tool."""
     speech = params.get('speech')
     

--- a/reachy_mini_mcp/tools_repository/scripts/turn_on_robot.py
+++ b/reachy_mini_mcp/tools_repository/scripts/turn_on_robot.py
@@ -4,7 +4,7 @@ Turns on the robot's motors and activates all systems.
 """
 
 
-async def execute(make_request, create_head_pose, tts_queue, params):
+async def execute(make_request, _create_head_pose, tts_queue, params):
     """Execute the turn_on_robot tool."""
     speech = params.get('speech')
     

--- a/reachy_mini_mcp/tts_queue.py
+++ b/reachy_mini_mcp/tts_queue.py
@@ -125,10 +125,10 @@ class TTSQueue:
             if result.returncode == 0:
                 _log(f"✓ piper found: {result.stdout.strip()}")
             else:
-                _log(f"⚠️  piper executable found but returned error")
+                _log("⚠️  piper executable found but returned error")
         except FileNotFoundError:
             _log(f"⚠️  piper not found at '{self.piper_executable}'")
-            _log(f"   Please install from: https://github.com/OHF-Voice/piper-gpl")
+            _log("   Please install from: https://github.com/OHF-Voice/piper-gpl")
         except Exception as e:
             _log(f"⚠️  Error checking piper: {e}")
     
@@ -195,14 +195,14 @@ class TTSQueue:
             )
             
             # Wait for playback to complete
-            stdout, stderr = self.current_process.communicate()
+            _, stderr = self.current_process.communicate()
             
             if self.current_process.returncode != 0:
                 _log(f"⚠️  aplay returned error code: {self.current_process.returncode}")
                 if stderr:
                     _log(f"   stderr: {stderr.decode('utf-8', errors='ignore')}")
             else:
-                _log(f"   ✓ Playback completed")
+                _log("   ✓ Playback completed")
             
             self.current_process = None
             

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -21,7 +21,7 @@ sonar.exclusions=**/__pycache__/**,**/.venv/**,uv.lock
 # extras CI can't build), so it's omitted from coverage in pyproject.toml. Mirror
 # that here as a COVERAGE exclusion only — these files stay indexed for bugs /
 # code smells / security hotspots, they just don't drag the coverage % to 0.
-sonar.coverage.exclusions=reachy_mini_mcp/server.py,reachy_mini_mcp/server_openai.py,reachy_mini_mcp/tts_queue.py,reachy_mini_mcp/tools_repository/**
+sonar.coverage.exclusions=reachy_mini_mcp/_runtime.py,reachy_mini_mcp/server.py,reachy_mini_mcp/server_openai.py,reachy_mini_mcp/tts_queue.py,reachy_mini_mcp/tools_repository/**
 
 # Block CI on a failing quality gate once the scan is active.
 sonar.qualitygate.wait=true


### PR DESCRIPTION
## What & why

SonarCloud on `main` was reporting Duplication **4.8%**, Security rating **E**
(one **BLOCKER** vulnerability), and **38** code smells. This clears all three
categories while keeping the manager-CLI test suite green at **99.6%** coverage
(the `fail_under = 95` gate holds).

## Duplication → shared runtime module

`server.py` and `server_openai.py` carried a byte-identical 79-line block. Those
helpers — `create_head_pose`, `make_request`, the tool-repo loaders, and the
`REACHY_BASE_URL` / `TOOLS_REPOSITORY_PATH` constants — now live once in
**`reachy_mini_mcp/_runtime.py`** and are imported by both servers. Orphaned
imports (`httpx`, `math`, `importlib.util`, `Path`, plus a pre-existing unused
`asyncio`/`JSONResponse`) were removed. The new module is coverage-excluded like
the other runtime files (it needs `httpx` + a live daemon).

## Security (S8392, BLOCKER) → configurable bind

The OpenAI server bound `uvicorn` to `0.0.0.0`. It now binds
`REACHY_OPENAI_HOST` (default **`127.0.0.1`**); set it to `0.0.0.0` for
Docker/cross-host reach. Documented in `.env.openai.example` and `CLAUDE.md`.

## Maintainability (38 smells)

- **S3776 + S3358** — `operate_robot` decomposed into `_run_command_sequence` /
  `_run_single_command` / `_execute_one_command` / `_append_state_result` /
  `_sequence_status`; complexity 40 → within limit, output preserved
  byte-for-byte (also kills the nested-ternary smell).
- **S8415 ×3** — FastAPI routes now document their `HTTPException` status codes.
- **S3457 ×4 / S1481 ×2** — placeholder-less f-strings and unused locals.
- **S1192** — duplicated literals → module constants (`claude_desktop_config.json`,
  `/api/move/goto`).
- **S3516 ×2** — `install`/`uninstall` handlers return `None` instead of an
  invariant `0` (the dispatcher already maps `None → 0`).
- **S5713** — redundant `URLError` dropped from an except tuple (it subclasses
  `OSError`).
- **S1172** — the unused params of the mandated `execute()` plugin signature are
  underscore-renamed across the affected tool scripts.

## Verification

- `python -m py_compile` on every changed file.
- **75 tests pass**, coverage **99.60%**.
- `operate_robot` exercised against a fake registry (11 single/sequence/edge
  cases) — identical output to before.
- All 13 edited tool scripts load and `execute()` positionally.
- Runtime behaviour (live daemon) verified separately per `CLAUDE.md`; the PR's
  SonarCloud re-scan is the authoritative gate.

Version bumped **0.2.1 → 0.2.2**.

> Note: clearing S1172 relies on Sonar honoring the leading-underscore
> convention. If the re-scan still shows them, the fallback is an inline
> `# NOSONAR` (or a scoped ignore rule for `tools_repository/scripts/*.py`).

- reachy-mini-mcp (Claude)
